### PR TITLE
refactor: enforce Go Report Card standards in CI (gocyclo, misspell, release chain)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,14 @@ name: Deploy to GitHub Pages and GHCR
 on:
   release:
     types: [published]
+  workflow_run:
+    workflows: ['Auto release']
+    types: [completed]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to deploy (e.g. v1.0.0)'
+        required: false
 
 permissions:
   contents: read
@@ -16,20 +23,50 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      skip: ${{ steps.tag.outputs.skip }}
+    steps:
+      - name: Resolve tag
+        id: tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            tag="${{ github.event.release.tag_name }}"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.tag }}" ]; then
+            tag="${{ inputs.tag }}"
+          else
+            tag=$(gh release view --repo ${{ github.repository }} --json tagName -q .tagName)
+          fi
+          if ! [[ "$tag" =~ ^v ]]; then
+            echo "Skipping: tag '$tag' does not start with v"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
   pages:
+    needs: resolve
+    if: needs.resolve.outputs.skip != 'true'
     runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ needs.resolve.outputs.tag }}
 
       - uses: actions/setup-go@v6.4.0
         with:
           go-version: '1.26'
 
       - name: Build WebAssembly bundle
-        run: make build VERSION=${{ github.event.release.tag_name || github.ref_name }}
+        run: make build VERSION=${{ needs.resolve.outputs.tag }}
 
       - uses: actions/configure-pages@v5
 
@@ -41,20 +78,17 @@ jobs:
         uses: actions/deploy-pages@v4
 
   docker:
+    needs: resolve
+    if: needs.resolve.outputs.skip != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ needs.resolve.outputs.tag }}
 
       - name: Compute lowercase repo
         id: repo
         run: echo "name=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
-
-      - name: Resolve tag
-        id: tag
-        run: |
-          tag="${{ github.event.release.tag_name }}"
-          if [ -z "$tag" ]; then tag="${{ github.ref_name }}"; fi
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-buildx-action@v4.0.0
 
@@ -71,10 +105,10 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/${{ steps.repo.outputs.name }}:${{ steps.tag.outputs.tag }}
+          tags: ghcr.io/${{ steps.repo.outputs.name }}:${{ needs.resolve.outputs.tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            VERSION=${{ steps.tag.outputs.tag }}
+            VERSION=${{ needs.resolve.outputs.tag }}
             GIT_COMMIT=${{ github.sha }}
-            BUILD_DATE=${{ github.event.release.published_at }}
+            BUILD_DATE=${{ github.event.release.published_at || github.event.workflow_run.updated_at }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,14 @@ name: Build and publish release artifacts
 on:
   release:
     types: [published]
+  workflow_run:
+    workflows: ['Auto release']
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to attach artifacts to (e.g. v1.0.0)'
+        required: true
 
 permissions:
   contents: write
@@ -10,27 +18,52 @@ permissions:
 jobs:
   bundle:
     runs-on: ubuntu-latest
-    if: startsWith(github.event.release.tag_name, 'v')
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     steps:
+      - name: Resolve tag
+        id: tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            tag="${{ github.event.release.tag_name }}"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            tag="${{ inputs.tag }}"
+          else
+            tag=$(gh release view --repo ${{ github.repository }} --json tagName -q .tagName)
+          fi
+          if ! [[ "$tag" =~ ^v ]]; then
+            echo "Skipping: tag '$tag' does not start with v"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v6.0.2
+        if: steps.tag.outputs.skip != 'true'
 
       - uses: actions/setup-go@v6.4.0
+        if: steps.tag.outputs.skip != 'true'
         with:
           go-version: '1.26'
 
       - name: Build WebAssembly bundle
-        run: make build VERSION=${{ github.event.release.tag_name }}
+        if: steps.tag.outputs.skip != 'true'
+        run: make build VERSION=${{ steps.tag.outputs.tag }}
 
       - name: Create web bundle tarball
+        if: steps.tag.outputs.skip != 'true'
         run: |
-          tar -czf awasm-portfolio-${{ github.event.release.tag_name }}.tgz -C web .
-          sha256sum awasm-portfolio-${{ github.event.release.tag_name }}.tgz > checksums.txt
+          tar -czf awasm-portfolio-${{ steps.tag.outputs.tag }}.tgz -C web .
+          sha256sum awasm-portfolio-${{ steps.tag.outputs.tag }}.tgz > checksums.txt
 
       - name: Publish to GitHub Release
+        if: steps.tag.outputs.skip != 'true'
         uses: softprops/action-gh-release@v3.0.0
         with:
+          tag_name: ${{ steps.tag.outputs.tag }}
           files: |
-            awasm-portfolio-${{ github.event.release.tag_name }}.tgz
+            awasm-portfolio-${{ steps.tag.outputs.tag }}.tgz
             checksums.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,18 @@
+version: "2"
+
+linters:
+  default: standard
+  enable:
+    - misspell
+
+  settings:
+    misspell:
+      locale: US
+      # Proper nouns (e.g. Spanish university names) that look like
+      # English misspellings but must stay verbatim.
+      ignore-rules:
+        - Internacional
+
+formatters:
+  enable:
+    - gofmt

--- a/ci.mk
+++ b/ci.mk
@@ -20,11 +20,7 @@ ci-vet:
 ci-cyclo:
 	@echo "==> Checking cyclomatic complexity..."
 	@go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
-	@# Test files are excluded — setup/assert blocks inflate cyclomatic
-	@# complexity without meaningful insight. schema.go is a data-driven
-	@# map literal; the apparent complexity reflects the number of resource
-	@# kinds, not branching logic.
-	@gocyclo -over 15 -ignore '(_test\.go|/schema\.go)$$' $$(find . -name '*.go' -not -path './web/*')
+	@gocyclo -over 15 $$(find . -name '*.go' -not -path './web/*')
 
 ci-lint:
 	@echo "==> Running golangci-lint..."

--- a/internal/repository/in_memory_repository_test.go
+++ b/internal/repository/in_memory_repository_test.go
@@ -1,11 +1,12 @@
 package repository_test
 
 import (
-	"github.com/TrianaLab/awasm-portfolio/internal/models"
-	"github.com/TrianaLab/awasm-portfolio/internal/repository"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/TrianaLab/awasm-portfolio/internal/models"
+	"github.com/TrianaLab/awasm-portfolio/internal/repository"
 )
 
 type mockResource struct {
@@ -16,197 +17,154 @@ type mockResource struct {
 	creationTimestamp time.Time
 }
 
-func (m *mockResource) GetKind() string {
-	return m.kind
-}
-
-func (m *mockResource) GetName() string {
-	return m.name
-}
-
-func (m *mockResource) SetName(name string) {
-	m.name = name
-}
-
-func (m *mockResource) GetNamespace() string {
-	return m.namespace
-}
-
-func (m *mockResource) SetNamespace(namespace string) {
-	m.namespace = namespace
-}
-
-func (m *mockResource) GetOwnerReference() models.OwnerReference {
-	return m.ownerRef
-}
-
+func (m *mockResource) GetKind() string                          { return m.kind }
+func (m *mockResource) GetName() string                          { return m.name }
+func (m *mockResource) SetName(name string)                      { m.name = name }
+func (m *mockResource) GetNamespace() string                     { return m.namespace }
+func (m *mockResource) SetNamespace(namespace string)            { m.namespace = namespace }
+func (m *mockResource) GetOwnerReference() models.OwnerReference { return m.ownerRef }
 func (m *mockResource) SetOwnerReference(owner models.OwnerReference) {
 	m.ownerRef = owner
 }
+func (m *mockResource) GetID() string                    { return m.kind + ":" + m.name + ":" + m.namespace }
+func (m *mockResource) GetCreationTimestamp() time.Time  { return m.creationTimestamp }
+func (m *mockResource) SetCreationTimestamp(t time.Time) { m.creationTimestamp = t }
 
-func (m *mockResource) GetID() string {
-	return m.kind + ":" + m.name + ":" + m.namespace
-}
-
-func (m *mockResource) GetCreationTimestamp() time.Time {
-	return m.creationTimestamp
-}
-
-func (m *mockResource) SetCreationTimestamp(timestamp time.Time) {
-	m.creationTimestamp = timestamp
-}
-
-func TestInMemoryRepository(t *testing.T) {
+func newRepoWithResume(t *testing.T) (*repository.InMemoryRepository, *mockResource) {
+	t.Helper()
 	repo := repository.NewInMemoryRepository()
 	now := time.Now()
+	ns := &mockResource{kind: "namespace", name: "default", creationTimestamp: now}
+	if _, err := repo.Create(ns); err != nil {
+		t.Fatalf("setup: create namespace: %v", err)
+	}
+	resume := &mockResource{kind: "resume", name: "test-resume", namespace: "default", creationTimestamp: now}
+	if _, err := repo.Create(resume); err != nil {
+		t.Fatalf("setup: create resume: %v", err)
+	}
+	return repo, resume
+}
 
-	resource := &mockResource{
-		kind:              "resume",
-		name:              "test-resume",
-		namespace:         "default",
-		creationTimestamp: now,
+func TestInMemoryRepository_CreateAndDuplicate(t *testing.T) {
+	repo := repository.NewInMemoryRepository()
+	now := time.Now()
+	resource := &mockResource{kind: "resume", name: "r1", namespace: "default", creationTimestamp: now}
+
+	msg, err := repo.Create(resource)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(msg, "created") {
+		t.Errorf("expected created message, got: %s", msg)
 	}
 
-	t.Run("Create", func(t *testing.T) {
-		namespace := &mockResource{
-			kind:              "namespace",
-			name:              "default",
-			creationTimestamp: now,
-		}
-		_, err := repo.Create(namespace)
-		if err != nil {
-			t.Fatalf("unexpected error creating namespace: %v", err)
-		}
+	if _, err := repo.Create(resource); err == nil {
+		t.Error("expected error creating duplicate resource")
+	}
+}
 
-		msg, err := repo.Create(resource)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if !strings.Contains(msg, "created") {
-			t.Errorf("expected created message, got: %s", msg)
-		}
+func TestInMemoryRepository_List(t *testing.T) {
+	repo, resume := newRepoWithResume(t)
 
-		_, err = repo.Create(resource)
-		if err == nil {
-			t.Error("expected error creating duplicate resource")
-		}
-	})
+	resources, err := repo.List(resume.GetKind(), resume.GetName(), resume.GetNamespace())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resources) != 1 || resources[0].GetID() != resume.GetID() {
+		t.Errorf("expected exactly resume in list, got %v", resources)
+	}
+}
 
-	t.Run("List", func(t *testing.T) {
-		resources, err := repo.List(resource.GetKind(), resource.GetName(), resource.GetNamespace())
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(resources) != 1 {
-			t.Errorf("expected 1 resource, got %d", len(resources))
-		}
-		if resources[0].GetID() != resource.GetID() {
-			t.Errorf("expected ID %s, got %s", resource.GetID(), resources[0].GetID())
-		}
+func TestInMemoryRepository_ListInvalidKind(t *testing.T) {
+	repo := repository.NewInMemoryRepository()
+	if _, err := repo.List("nonexistent", "", ""); err == nil {
+		t.Error("expected error for invalid kind")
+	}
+}
 
-		_, err = repo.List("nonexistent", "", "")
-		if err == nil {
-			t.Error("expected error for invalid kind")
-		}
+func TestInMemoryRepository_ListEmptyNamespace(t *testing.T) {
+	repo, _ := newRepoWithResume(t)
+	resources, err := repo.List("resume", "", "invalid-ns")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resources) != 0 {
+		t.Errorf("expected 0 resources, got %d", len(resources))
+	}
+}
 
-		resources, err = repo.List("resume", "", "invalid-ns")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(resources) != 0 {
-			t.Errorf("expected 0 resources, got %d", len(resources))
-		}
-	})
+func TestInMemoryRepository_Delete(t *testing.T) {
+	repo, resume := newRepoWithResume(t)
 
-	t.Run("Delete", func(t *testing.T) {
-		msg, err := repo.Delete(resource.GetKind(), resource.GetName(), resource.GetNamespace())
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if !strings.Contains(msg, "deleted") {
-			t.Errorf("expected deleted message, got: %s", msg)
-		}
+	msg, err := repo.Delete(resume.GetKind(), resume.GetName(), resume.GetNamespace())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(msg, "deleted") {
+		t.Errorf("expected deleted message, got: %s", msg)
+	}
+}
 
-		_, err = repo.Delete("resume", "nonexistent", "default")
-		if err == nil {
-			t.Error("expected error deleting nonexistent resource")
-		}
+func TestInMemoryRepository_DeleteNonexistent(t *testing.T) {
+	repo := repository.NewInMemoryRepository()
+	if _, err := repo.Delete("resume", "nonexistent", "default"); err == nil {
+		t.Error("expected error deleting nonexistent resource")
+	}
+}
 
-		_, err = repo.Delete("invalid", "name", "default")
-		if err == nil {
-			t.Error("expected error for invalid kind")
-		}
-	})
+func TestInMemoryRepository_DeleteInvalidKind(t *testing.T) {
+	repo := repository.NewInMemoryRepository()
+	if _, err := repo.Delete("invalid", "name", "default"); err == nil {
+		t.Error("expected error for invalid kind")
+	}
+}
 
-	t.Run("List All Namespaces", func(t *testing.T) {
-		resource2 := &mockResource{
-			kind:              "resume",
-			name:              "test-resume-2",
-			namespace:         "other",
-			creationTimestamp: now,
-		}
+func TestInMemoryRepository_ListAcrossNamespaces(t *testing.T) {
+	repo, _ := newRepoWithResume(t)
+	now := time.Now()
 
-		namespace2 := &mockResource{
-			kind:              "namespace",
-			name:              "other",
-			creationTimestamp: now,
-		}
-		_, _ = repo.Create(namespace2)
-		_, _ = repo.Create(resource2)
+	other := &mockResource{kind: "namespace", name: "other", creationTimestamp: now}
+	if _, err := repo.Create(other); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	otherResume := &mockResource{kind: "resume", name: "r2", namespace: "other", creationTimestamp: now}
+	if _, err := repo.Create(otherResume); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
 
-		resources, err := repo.List("resume", "", "")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(resources) != 1 {
-			t.Errorf("expected 1 resource, got %d", len(resources))
-		}
+	resources, err := repo.List("namespace", "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resources) != 2 {
+		t.Errorf("expected 2 namespaces, got %d", len(resources))
+	}
+}
 
-		resources, err = repo.List("namespace", "", "")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(resources) != 2 {
-			t.Errorf("expected 2 namespaces, got %d", len(resources))
-		}
-	})
+func TestInMemoryRepository_CreateStampsZeroTimestamp(t *testing.T) {
+	repo := repository.NewInMemoryRepository()
+	r := &mockResource{kind: "resume", name: "no-ts", namespace: "default"}
+	if _, err := repo.Create(r); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.GetCreationTimestamp().IsZero() {
+		t.Error("Create did not auto-stamp a zero CreationTimestamp")
+	}
+}
 
-	t.Run("Create Stamps Zero Timestamp", func(t *testing.T) {
-		// A resource with a zero CreationTimestamp triggers the auto-stamp branch.
-		r := &mockResource{
-			kind:      "resume",
-			name:      "no-ts",
-			namespace: "default",
-		}
-		if _, err := repo.Create(r); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if r.GetCreationTimestamp().IsZero() {
-			t.Error("Create did not auto-stamp a zero CreationTimestamp")
-		}
-	})
-
-	t.Run("Create Preserves Non-Zero Timestamp", func(t *testing.T) {
-		fixed := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
-		r := &mockResource{
-			kind:              "resume",
-			name:              "with-ts",
-			namespace:         "default",
-			creationTimestamp: fixed,
-		}
-		if _, err := repo.Create(r); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		stored, err := repo.List("resume", "with-ts", "default")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(stored) != 1 {
-			t.Fatalf("expected 1 stored resource, got %d", len(stored))
-		}
-		if !stored[0].GetCreationTimestamp().Equal(fixed) {
-			t.Errorf("Create overwrote a non-zero CreationTimestamp: got %v, want %v",
-				stored[0].GetCreationTimestamp(), fixed)
-		}
-	})
+func TestInMemoryRepository_CreatePreservesNonZeroTimestamp(t *testing.T) {
+	repo := repository.NewInMemoryRepository()
+	fixed := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
+	r := &mockResource{kind: "resume", name: "with-ts", namespace: "default", creationTimestamp: fixed}
+	if _, err := repo.Create(r); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	stored, err := repo.List("resume", "with-ts", "default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stored) != 1 || !stored[0].GetCreationTimestamp().Equal(fixed) {
+		t.Errorf("Create overwrote CreationTimestamp: got %v, want %v",
+			stored[0].GetCreationTimestamp(), fixed)
+	}
 }

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,12 +1,13 @@
 package service_test
 
 import (
-	"github.com/TrianaLab/awasm-portfolio/internal/models"
-	"github.com/TrianaLab/awasm-portfolio/internal/repository"
-	"github.com/TrianaLab/awasm-portfolio/internal/service"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/TrianaLab/awasm-portfolio/internal/models"
+	"github.com/TrianaLab/awasm-portfolio/internal/repository"
+	"github.com/TrianaLab/awasm-portfolio/internal/service"
 
 	"github.com/spf13/cobra"
 )
@@ -44,26 +45,46 @@ func newTestResource(kind, name, namespace string) models.Resource {
 	}
 }
 
-func TestCreateService(t *testing.T) {
+func mustCreate(t *testing.T, repo *repository.InMemoryRepository, r models.Resource) {
+	t.Helper()
+	if _, err := repo.Create(r); err != nil {
+		t.Fatalf("setup: create %s/%s: %v", r.GetKind(), r.GetName(), err)
+	}
+}
+
+func assertErrContains(t *testing.T, err error, substr string) {
+	t.Helper()
+	if err == nil {
+		t.Errorf("expected error containing %q, got nil", substr)
+		return
+	}
+	if !strings.Contains(err.Error(), substr) {
+		t.Errorf("expected error containing %q, got %v", substr, err)
+	}
+}
+
+// ---------------- CreateService ----------------
+
+func newCreateServiceFixture() (*repository.InMemoryRepository, *service.CreateService) {
 	repo := repository.NewInMemoryRepository()
-	cmd := newTestCommand()
-	cs := service.NewCreateService(repo, cmd)
+	return repo, service.NewCreateService(repo, newTestCommand())
+}
 
+func TestCreateService_InvalidKind(t *testing.T) {
+	_, cs := newCreateServiceFixture()
 	_, err := cs.CreateResource("invalidKind", "testName", "testNS")
-	if err == nil || !strings.Contains(err.Error(), "unsupported resource kind") {
-		t.Errorf("expected unsupported resource kind error, got %v", err)
-	}
+	assertErrContains(t, err, "unsupported resource kind")
+}
 
-	_, err = cs.CreateResource("resume", "testName", "nonexistentNS")
-	if err == nil || !strings.Contains(err.Error(), "namespace 'nonexistentNS' not found") {
-		t.Errorf("expected namespace not found error, got %v", err)
-	}
+func TestCreateService_MissingNamespace(t *testing.T) {
+	_, cs := newCreateServiceFixture()
+	_, err := cs.CreateResource("resume", "testName", "nonexistentNS")
+	assertErrContains(t, err, "namespace 'nonexistentNS' not found")
+}
 
-	namespace := newTestResource("namespace", "test", "")
-	_, err = repo.Create(namespace)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+func TestCreateService_Success(t *testing.T) {
+	repo, cs := newCreateServiceFixture()
+	mustCreate(t, repo, newTestResource("namespace", "test", ""))
 
 	msg, err := cs.CreateResource("resume", "testResume", "test")
 	if err != nil {
@@ -72,129 +93,104 @@ func TestCreateService(t *testing.T) {
 	if !strings.Contains(msg, "resume/testResume created") {
 		t.Errorf("unexpected success message: %s", msg)
 	}
-
-	t.Run("Duplicate Create Errors", func(t *testing.T) {
-		// CreateResource("namespace", "test", "") — already exists; main repo.Create fails.
-		_, err := cs.CreateResource("namespace", "test", "")
-		if err == nil {
-			t.Error("expected error creating duplicate namespace")
-		}
-	})
-
-	t.Run("Resume Basics Conflict", func(t *testing.T) {
-		ns := newTestResource("namespace", "basics-conflict-ns", "")
-		if _, err := repo.Create(ns); err != nil {
-			t.Fatalf("setup error: %v", err)
-		}
-
-		// Pre-create the basics resource that the resume would create.
-		preBasics := newTestResource("basics", "basics-conflict-basics", "basics-conflict-ns")
-		if _, err := repo.Create(preBasics); err != nil {
-			t.Fatalf("setup error: %v", err)
-		}
-
-		// CreateResource for a resume named "basics-conflict" will derive basics
-		// name "basics-conflict-basics" and collide with the pre-existing one.
-		_, err := cs.CreateResource("resume", "basics-conflict", "basics-conflict-ns")
-		if err == nil || !strings.Contains(err.Error(), "failed to save basics") {
-			t.Errorf("expected 'failed to save basics' error, got %v", err)
-		}
-	})
-
-	t.Run("Resume Nested Element Conflict", func(t *testing.T) {
-		ns := newTestResource("namespace", "nested-conflict-ns", "")
-		if _, err := repo.Create(ns); err != nil {
-			t.Fatalf("setup error: %v", err)
-		}
-
-		// Pre-create one of the nested elements the resume factory will produce.
-		// The factory generates >=1 work entry; first one is "<name>-Work-0".
-		preWork := newTestResource("work", "nested-conflict-work-0", "nested-conflict-ns")
-		if _, err := repo.Create(preWork); err != nil {
-			t.Fatalf("setup error: %v", err)
-		}
-
-		_, err := cs.CreateResource("resume", "nested-conflict", "nested-conflict-ns")
-		if err == nil || !strings.Contains(err.Error(), "failed to save") {
-			t.Errorf("expected 'failed to save' error, got %v", err)
-		}
-	})
-
-	t.Run("Create Resume With Nested Resources", func(t *testing.T) {
-		namespace := newTestResource("namespace", "nested-test", "")
-		_, err := repo.Create(namespace)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		_, err = cs.CreateResource("resume", "test-nested", "nested-test")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		types := []string{
-			"work", "education", "volunteer", "award", "skill",
-			"language", "interest", "reference", "project", "basics",
-		}
-
-		for _, typ := range types {
-			resources, err := repo.List(typ, "", "nested-test")
-			if err != nil {
-				t.Errorf("error listing %s: %v", typ, err)
-			}
-			if len(resources) == 0 {
-				t.Errorf("no %s resources created", typ)
-			}
-
-			for _, res := range resources {
-				ownerRef := res.GetOwnerReference()
-				if ownerRef.Kind != "resume" {
-					t.Errorf("expected owner kind resume, got %s", ownerRef.Kind)
-				}
-				if ownerRef.Name != "test-nested" {
-					t.Errorf("expected owner name test-nested, got %s", ownerRef.Name)
-				}
-				if ownerRef.Namespace != "nested-test" {
-					t.Errorf("expected owner namespace nested-test, got %s", ownerRef.Namespace)
-				}
-				if res.GetNamespace() != "nested-test" {
-					t.Errorf("expected namespace nested-test, got %s", res.GetNamespace())
-				}
-			}
-		}
-	})
 }
 
-func TestDeleteService(t *testing.T) {
+func TestCreateService_DuplicateErrors(t *testing.T) {
+	repo, cs := newCreateServiceFixture()
+	mustCreate(t, repo, newTestResource("namespace", "dup", ""))
+
+	_, err := cs.CreateResource("namespace", "dup", "")
+	if err == nil {
+		t.Error("expected error creating duplicate namespace")
+	}
+}
+
+func TestCreateService_ResumeBasicsConflict(t *testing.T) {
+	repo, cs := newCreateServiceFixture()
+	mustCreate(t, repo, newTestResource("namespace", "basics-conflict-ns", ""))
+	// Pre-create the basics resource that the resume would derive.
+	mustCreate(t, repo, newTestResource("basics", "basics-conflict-basics", "basics-conflict-ns"))
+
+	_, err := cs.CreateResource("resume", "basics-conflict", "basics-conflict-ns")
+	assertErrContains(t, err, "failed to save basics")
+}
+
+func TestCreateService_ResumeNestedConflict(t *testing.T) {
+	repo, cs := newCreateServiceFixture()
+	mustCreate(t, repo, newTestResource("namespace", "nested-conflict-ns", ""))
+	// First nested work entry the factory produces is "<name>-Work-0".
+	mustCreate(t, repo, newTestResource("work", "nested-conflict-work-0", "nested-conflict-ns"))
+
+	_, err := cs.CreateResource("resume", "nested-conflict", "nested-conflict-ns")
+	assertErrContains(t, err, "failed to save")
+}
+
+func TestCreateService_ResumeWithNestedResources(t *testing.T) {
+	repo, cs := newCreateServiceFixture()
+	mustCreate(t, repo, newTestResource("namespace", "nested-test", ""))
+
+	if _, err := cs.CreateResource("resume", "test-nested", "nested-test"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	kinds := []string{
+		"work", "education", "volunteer", "award", "skill",
+		"language", "interest", "reference", "project", "basics",
+	}
+	for _, typ := range kinds {
+		assertNestedChildren(t, repo, typ, "test-nested", "nested-test")
+	}
+}
+
+func assertNestedChildren(t *testing.T, repo *repository.InMemoryRepository, kind, parent, namespace string) {
+	t.Helper()
+	resources, err := repo.List(kind, "", namespace)
+	if err != nil {
+		t.Errorf("error listing %s: %v", kind, err)
+	}
+	if len(resources) == 0 {
+		t.Errorf("no %s resources created", kind)
+	}
+	for _, res := range resources {
+		owner := res.GetOwnerReference()
+		if owner.Kind != "resume" || owner.Name != parent || owner.Namespace != namespace {
+			t.Errorf("%s/%s: wrong owner %+v", kind, res.GetName(), owner)
+		}
+		if res.GetNamespace() != namespace {
+			t.Errorf("%s/%s: wrong namespace %q", kind, res.GetName(), res.GetNamespace())
+		}
+	}
+}
+
+// ---------------- DeleteService ----------------
+
+func newDeleteServiceFixture() (*repository.InMemoryRepository, *service.DeleteService) {
 	repo := repository.NewInMemoryRepository()
-	cmd := newTestCommand()
-	ds := service.NewDeleteService(repo, cmd)
+	return repo, service.NewDeleteService(repo, newTestCommand())
+}
 
+func TestDeleteService_InvalidKind(t *testing.T) {
+	_, ds := newDeleteServiceFixture()
 	_, err := ds.DeleteResource("invalidKind", "testName", "test")
-	if err == nil || !strings.Contains(err.Error(), "unsupported resource kind") {
-		t.Errorf("expected unsupported resource kind error, got %v", err)
-	}
+	assertErrContains(t, err, "unsupported resource kind")
+}
 
-	_, err = ds.DeleteResource("resume", "", "test")
-	if err == nil || !strings.Contains(err.Error(), "no name was specified") {
-		t.Errorf("expected missing name error, got %v", err)
-	}
+func TestDeleteService_MissingName(t *testing.T) {
+	_, ds := newDeleteServiceFixture()
+	_, err := ds.DeleteResource("resume", "", "test")
+	assertErrContains(t, err, "no name was specified")
+}
 
-	_, err = ds.DeleteResource("resume", "testName", "")
-	if err == nil || !strings.Contains(err.Error(), "cannot be retrieved by name across all namespaces") {
-		t.Errorf("expected missing namespace error, got %v", err)
-	}
+func TestDeleteService_MissingNamespace(t *testing.T) {
+	_, ds := newDeleteServiceFixture()
+	_, err := ds.DeleteResource("resume", "testName", "")
+	assertErrContains(t, err, "cannot be retrieved by name across all namespaces")
+}
 
-	namespace := newTestResource("namespace", "test", "")
-	_, err = repo.Create(namespace)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	resume := newTestResource("resume", "testResume", "test")
-	_, err = repo.Create(resume)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+func TestDeleteService_Namespace(t *testing.T) {
+	repo, ds := newDeleteServiceFixture()
+	mustCreate(t, repo, newTestResource("namespace", "test", ""))
+	mustCreate(t, repo, newTestResource("resume", "testResume", "test"))
 
 	msg, err := ds.DeleteResource("namespace", "test", "")
 	if err != nil {
@@ -203,277 +199,185 @@ func TestDeleteService(t *testing.T) {
 	if !strings.Contains(msg, "namespace/test in namespace '' deleted") {
 		t.Errorf("unexpected success message: %s", msg)
 	}
-
-	_, err = ds.DeleteResource("namespace", "inexistent", "")
-	if err == nil || !strings.Contains(err.Error(), "namespace/inexistent not found in namespace ''") {
-		t.Errorf("expected missing namespace error, got %v", err)
-	}
-
-	t.Run("Empty Kind", func(t *testing.T) {
-		_, err := ds.DeleteResource("", "test", "default")
-		if err == nil {
-			t.Error("expected error for empty kind")
-		}
-		if !strings.Contains(err.Error(), "unsupported resource kind") {
-			t.Errorf("expected 'unsupported resource kind' error, got %v", err)
-		}
-	})
-
-	t.Run("Delete With Owner References", func(t *testing.T) {
-		namespace := newTestResource("namespace", "test-ns", "")
-		_, err := repo.Create(namespace)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		parent := newTestResource("resume", "parent-resume", "test-ns")
-		_, err = repo.Create(parent)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		parentID := strings.ToLower("resume:parent-resume:test-ns")
-
-		child1 := &dummyResource{
-			Kind:      "work",
-			Name:      "child-work",
-			Namespace: "test-ns",
-			ownerRef: models.OwnerReference{
-				Kind:      "resume",
-				Name:      "parent-resume",
-				Namespace: "test-ns",
-			},
-		}
-		_, err = repo.Create(child1)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		child2 := &dummyResource{
-			Kind:      "education",
-			Name:      "child-edu",
-			Namespace: "test-ns",
-			ownerRef: models.OwnerReference{
-				Kind:      "resume",
-				Name:      "parent-resume",
-				Namespace: "test-ns",
-			},
-		}
-		_, err = repo.Create(child2)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		resources, _ := repo.List("work", "", "test-ns")
-		if len(resources) == 0 || resources[0].GetOwnerReference().GetID() != parentID {
-			t.Fatal("child work not created with correct owner reference")
-		}
-
-		resources, _ = repo.List("education", "", "test-ns")
-		if len(resources) == 0 || resources[0].GetOwnerReference().GetID() != parentID {
-			t.Fatal("child education not created with correct owner reference")
-		}
-
-		msg, err := ds.DeleteResource("resume", "parent-resume", "test-ns")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		if !strings.Contains(msg, "resume/parent-resume") {
-			t.Error("parent resource not mentioned in delete message")
-		}
-		if !strings.Contains(msg, "work/child-work") {
-			t.Error("child work not mentioned in delete message")
-		}
-		if !strings.Contains(msg, "education/child-edu") {
-			t.Error("child education not mentioned in delete message")
-		}
-
-		resources, _ = repo.List("work", "", "test-ns")
-		if len(resources) > 0 {
-			t.Error("child work still exists after parent deletion")
-		}
-
-		resources, _ = repo.List("education", "", "test-ns")
-		if len(resources) > 0 {
-			t.Error("child education still exists after parent deletion")
-		}
-	})
-
-	t.Run("No Resource Specified", func(t *testing.T) {
-		_, err := ds.DeleteResource("all", "", "default")
-		if err == nil {
-			t.Error("expected error for no resource specified")
-		}
-		if !strings.Contains(err.Error(), "you must specify only one resource") {
-			t.Errorf("expected 'you must specify only one resource' error, got %v", err)
-		}
-	})
-
-	t.Run("Delete Error Cases", func(t *testing.T) {
-		_, err := ds.DeleteResource("resume", "nonexistent", "nonexistent")
-		if err == nil || !strings.Contains(err.Error(), "not found") {
-			t.Errorf("expected 'not found' error, got %v", err)
-		}
-
-		namespace := newTestResource("namespace", "test-ns2", "")
-		_, _ = repo.Create(namespace)
-
-		parent := newTestResource("resume", "parent2", "test-ns2")
-		_, _ = repo.Create(parent)
-
-		child := &dummyResource{
-			Kind:      "work",
-			Name:      "child2",
-			Namespace: "test-ns2",
-			ownerRef: models.OwnerReference{
-				Kind:      "resume",
-				Name:      "parent2",
-				Namespace: "test-ns2",
-			},
-		}
-		_, _ = repo.Create(child)
-
-		msg, err := ds.DeleteResource("work", "child2", "test-ns2")
-		if err != nil {
-			t.Errorf("unexpected error when deleting child: %v", err)
-		}
-		if !strings.Contains(msg, "work/child2") {
-			t.Error("child deletion message not found")
-		}
-
-		msg, err = ds.DeleteResource("namespace", "test-ns2", "")
-		if err != nil {
-			t.Errorf("unexpected error when deleting namespace: %v", err)
-		}
-		if !strings.Contains(msg, "namespace/test-ns2") {
-			t.Error("namespace deletion message not found")
-		}
-	})
 }
 
-func TestDescribeService(t *testing.T) {
+func TestDeleteService_NamespaceNotFound(t *testing.T) {
+	_, ds := newDeleteServiceFixture()
+	_, err := ds.DeleteResource("namespace", "inexistent", "")
+	assertErrContains(t, err, "namespace/inexistent not found in namespace ''")
+}
+
+func TestDeleteService_EmptyKind(t *testing.T) {
+	_, ds := newDeleteServiceFixture()
+	_, err := ds.DeleteResource("", "test", "default")
+	assertErrContains(t, err, "unsupported resource kind")
+}
+
+func TestDeleteService_AllNoName(t *testing.T) {
+	_, ds := newDeleteServiceFixture()
+	_, err := ds.DeleteResource("all", "", "default")
+	assertErrContains(t, err, "you must specify only one resource")
+}
+
+func TestDeleteService_WithOwnerReferences(t *testing.T) {
+	repo, ds := newDeleteServiceFixture()
+	mustCreate(t, repo, newTestResource("namespace", "test-ns", ""))
+	mustCreate(t, repo, newTestResource("resume", "parent-resume", "test-ns"))
+	parentOwner := models.OwnerReference{Kind: "resume", Name: "parent-resume", Namespace: "test-ns"}
+	mustCreate(t, repo, &dummyResource{Kind: "work", Name: "child-work", Namespace: "test-ns", ownerRef: parentOwner})
+	mustCreate(t, repo, &dummyResource{Kind: "education", Name: "child-edu", Namespace: "test-ns", ownerRef: parentOwner})
+
+	msg, err := ds.DeleteResource("resume", "parent-resume", "test-ns")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{"resume/parent-resume", "work/child-work", "education/child-edu"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("delete message missing %q: %s", want, msg)
+		}
+	}
+	assertEmptyList(t, repo, "work", "test-ns")
+	assertEmptyList(t, repo, "education", "test-ns")
+}
+
+func assertEmptyList(t *testing.T, repo *repository.InMemoryRepository, kind, namespace string) {
+	t.Helper()
+	resources, _ := repo.List(kind, "", namespace)
+	if len(resources) > 0 {
+		t.Errorf("expected no %s remaining in %s, got %d", kind, namespace, len(resources))
+	}
+}
+
+func TestDeleteService_NonexistentResume(t *testing.T) {
+	_, ds := newDeleteServiceFixture()
+	_, err := ds.DeleteResource("resume", "nonexistent", "nonexistent")
+	assertErrContains(t, err, "not found")
+}
+
+func TestDeleteService_ChildThenNamespace(t *testing.T) {
+	repo, ds := newDeleteServiceFixture()
+	mustCreate(t, repo, newTestResource("namespace", "test-ns2", ""))
+	mustCreate(t, repo, newTestResource("resume", "parent2", "test-ns2"))
+	mustCreate(t, repo, &dummyResource{
+		Kind: "work", Name: "child2", Namespace: "test-ns2",
+		ownerRef: models.OwnerReference{Kind: "resume", Name: "parent2", Namespace: "test-ns2"},
+	})
+
+	msg, err := ds.DeleteResource("work", "child2", "test-ns2")
+	if err != nil {
+		t.Errorf("unexpected error deleting child: %v", err)
+	}
+	if !strings.Contains(msg, "work/child2") {
+		t.Error("child deletion message not found")
+	}
+
+	msg, err = ds.DeleteResource("namespace", "test-ns2", "")
+	if err != nil {
+		t.Errorf("unexpected error deleting namespace: %v", err)
+	}
+	if !strings.Contains(msg, "namespace/test-ns2") {
+		t.Error("namespace deletion message not found")
+	}
+}
+
+// ---------------- DescribeService ----------------
+
+func newDescribeServiceFixture() (*repository.InMemoryRepository, *service.DescribeService) {
 	repo := repository.NewInMemoryRepository()
-	cmd := newTestCommand()
-	ds := service.NewDescribeService(repo, cmd)
+	return repo, service.NewDescribeService(repo, newTestCommand())
+}
 
+func TestDescribeService_MissingNamespace(t *testing.T) {
+	_, ds := newDescribeServiceFixture()
 	_, err := ds.DescribeResource("resume", "testName", "")
-	if err == nil || !strings.Contains(err.Error(), "cannot be retrieved by name across all namespaces") {
-		t.Errorf("expected missing namespace error, got %v", err)
-	}
+	assertErrContains(t, err, "cannot be retrieved by name across all namespaces")
+}
 
-	namespace := newTestResource("namespace", "testNS", "")
-	_, err = repo.Create(namespace)
+func TestDescribeService_Success(t *testing.T) {
+	repo, ds := newDescribeServiceFixture()
+	mustCreate(t, repo, newTestResource("namespace", "testNS", ""))
+	mustCreate(t, repo, newTestResource("resume", "testResume", "testNS"))
+
+	msg, err := ds.DescribeResource("resume", "testResume", "testNS")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	resume := newTestResource("resume", "testResume", "testNS")
-	_, err = repo.Create(resume)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	msg, err2 := ds.DescribeResource("resume", "testResume", "testNS")
-	if err2 != nil {
-		t.Fatalf("unexpected error: %v", err2)
 	}
 	if !strings.Contains(msg, "testResume") {
 		t.Errorf("unexpected description output: %s", msg)
 	}
-
-	t.Run("Describe All Resources", func(t *testing.T) {
-		resources := []struct {
-			kind      string
-			name      string
-			namespace string
-		}{
-			{"work", "work-1", "testNS"},
-			{"education", "edu-1", "testNS"},
-			{"skill", "skill-1", "testNS"},
-		}
-
-		for _, r := range resources {
-			res := newTestResource(r.kind, r.name, r.namespace)
-			_, err := repo.Create(res)
-			if err != nil {
-				t.Fatalf("error creating resource %s/%s: %v", r.kind, r.name, err)
-			}
-		}
-
-		for _, r := range resources {
-			msg, err := ds.DescribeResource(r.kind, "", r.namespace)
-			if err != nil {
-				t.Errorf("error describing all %s: %v", r.kind, err)
-			}
-			if !strings.Contains(msg, r.name) {
-				t.Errorf("expected %s in output, got: %s", r.name, msg)
-			}
-		}
-	})
-
-	t.Run("Describe All With Namespace", func(t *testing.T) {
-		ns1 := newTestResource("namespace", "ns1", "")
-		ns2 := newTestResource("namespace", "ns2", "")
-		_, _ = repo.Create(ns1)
-		_, _ = repo.Create(ns2)
-
-		resources := []struct {
-			kind      string
-			name      string
-			namespace string
-		}{
-			{"work", "work-1", "ns1"},
-			{"work", "work-2", "ns2"},
-			{"education", "edu-1", "ns1"},
-			{"education", "edu-2", "ns2"},
-		}
-
-		for _, r := range resources {
-			res := newTestResource(r.kind, r.name, r.namespace)
-			_, _ = repo.Create(res)
-		}
-
-		msg, err := ds.DescribeResource("all", "", "ns1")
-		if err != nil {
-			t.Fatalf("error describing all resources: %v", err)
-		}
-
-		if strings.Contains(msg, "work-2") || strings.Contains(msg, "edu-2") {
-			t.Error("found resources from wrong namespace")
-		}
-		if !strings.Contains(msg, "work-1") || !strings.Contains(msg, "edu-1") {
-			t.Error("missing resources from correct namespace")
-		}
-		if !strings.Contains(msg, "ns1") || strings.Contains(msg, "ns2") {
-			t.Error("incorrect namespace filtering")
-		}
-	})
 }
 
-func TestGetService(t *testing.T) {
+func TestDescribeService_AllInNamespace(t *testing.T) {
+	repo, ds := newDescribeServiceFixture()
+	mustCreate(t, repo, newTestResource("namespace", "testNS", ""))
+	kinds := []struct{ kind, name string }{
+		{"work", "work-1"},
+		{"education", "edu-1"},
+		{"skill", "skill-1"},
+	}
+	for _, k := range kinds {
+		mustCreate(t, repo, newTestResource(k.kind, k.name, "testNS"))
+	}
+
+	for _, k := range kinds {
+		msg, err := ds.DescribeResource(k.kind, "", "testNS")
+		if err != nil {
+			t.Errorf("error describing all %s: %v", k.kind, err)
+		}
+		if !strings.Contains(msg, k.name) {
+			t.Errorf("expected %s in output, got: %s", k.name, msg)
+		}
+	}
+}
+
+func TestDescribeService_AllWithNamespaceFilter(t *testing.T) {
+	repo, ds := newDescribeServiceFixture()
+	mustCreate(t, repo, newTestResource("namespace", "ns1", ""))
+	mustCreate(t, repo, newTestResource("namespace", "ns2", ""))
+	for _, r := range []struct{ kind, name, ns string }{
+		{"work", "work-1", "ns1"}, {"work", "work-2", "ns2"},
+		{"education", "edu-1", "ns1"}, {"education", "edu-2", "ns2"},
+	} {
+		mustCreate(t, repo, newTestResource(r.kind, r.name, r.ns))
+	}
+
+	msg, err := ds.DescribeResource("all", "", "ns1")
+	if err != nil {
+		t.Fatalf("error describing all resources: %v", err)
+	}
+	if strings.Contains(msg, "work-2") || strings.Contains(msg, "edu-2") {
+		t.Error("found resources from wrong namespace")
+	}
+	if !strings.Contains(msg, "work-1") || !strings.Contains(msg, "edu-1") {
+		t.Error("missing resources from correct namespace")
+	}
+	if !strings.Contains(msg, "ns1") || strings.Contains(msg, "ns2") {
+		t.Error("incorrect namespace filtering")
+	}
+}
+
+// ---------------- GetService ----------------
+
+func newGetServiceFixture(t *testing.T) (*repository.InMemoryRepository, *cobra.Command, *service.GetService) {
+	t.Helper()
 	repo := repository.NewInMemoryRepository()
 	cmd := newTestCommand()
-	err := cmd.Flags().Set("output", "json")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if err := cmd.Flags().Set("output", "json"); err != nil {
+		t.Fatalf("flag setup: %v", err)
 	}
-	gs := service.NewGetService(repo, cmd)
+	return repo, cmd, service.NewGetService(repo, cmd)
+}
 
-	_, err = gs.GetResources("resume", "testName", "")
-	if err == nil || !strings.Contains(err.Error(), "cannot be retrieved by name across all namespaces") {
-		t.Errorf("expected missing namespace error, got %v", err)
-	}
+func TestGetService_MissingNamespace(t *testing.T) {
+	_, _, gs := newGetServiceFixture(t)
+	_, err := gs.GetResources("resume", "testName", "")
+	assertErrContains(t, err, "cannot be retrieved by name across all namespaces")
+}
 
-	namespace := newTestResource("namespace", "testNS", "")
-	_, err = repo.Create(namespace)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	resume := newTestResource("resume", "testResume", "testNS")
-	_, err = repo.Create(resume)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+func TestGetService_Success(t *testing.T) {
+	repo, _, gs := newGetServiceFixture(t)
+	mustCreate(t, repo, newTestResource("namespace", "testNS", ""))
+	mustCreate(t, repo, newTestResource("resume", "testResume", "testNS"))
 
 	msg, err := gs.GetResources("resume", "", "testNS")
 	if err != nil {
@@ -482,48 +386,36 @@ func TestGetService(t *testing.T) {
 	if !strings.Contains(msg, "testResume") {
 		t.Errorf("unexpected retrieval output: %s", msg)
 	}
-
-	t.Run("Get Resources Without Namespaces", func(t *testing.T) {
-		resources := []struct {
-			kind      string
-			name      string
-			namespace string
-		}{
-			{"namespace", "ns1", ""},
-			{"namespace", "ns2", ""},
-			{"work", "work-1", "ns1"},
-			{"education", "edu-1", "ns1"},
-		}
-
-		for _, r := range resources {
-			res := newTestResource(r.kind, r.name, r.namespace)
-			_, err := repo.Create(res)
-			if err != nil {
-				t.Fatalf("error creating resource %s/%s: %v", r.kind, r.name, err)
-			}
-		}
-
-		err := cmd.Flags().Set("output", "json")
-		if err != nil {
-			t.Fatalf("error setting flag: %v", err)
-		}
-
-		msg, err := gs.GetResources("all", "", "")
-		if err != nil {
-			t.Fatalf("error getting resources: %v", err)
-		}
-
-		if strings.Contains(msg, "\"Kind\": \"namespace\"") {
-			t.Error("namespaces should not be included in output")
-		}
-		if !strings.Contains(msg, "\"Kind\": \"work\"") {
-			t.Error("work resources should be included in output")
-		}
-		if !strings.Contains(msg, "\"Kind\": \"education\"") {
-			t.Error("education resources should be included in output")
-		}
-	})
 }
+
+func TestGetService_AllAcrossNamespaces(t *testing.T) {
+	repo, cmd, gs := newGetServiceFixture(t)
+	for _, r := range []struct{ kind, name, ns string }{
+		{"namespace", "ns1", ""}, {"namespace", "ns2", ""},
+		{"work", "work-1", "ns1"}, {"education", "edu-1", "ns1"},
+	} {
+		mustCreate(t, repo, newTestResource(r.kind, r.name, r.ns))
+	}
+	if err := cmd.Flags().Set("output", "json"); err != nil {
+		t.Fatalf("flag setup: %v", err)
+	}
+
+	msg, err := gs.GetResources("all", "", "")
+	if err != nil {
+		t.Fatalf("error getting resources: %v", err)
+	}
+	if strings.Contains(msg, "\"Kind\": \"namespace\"") {
+		t.Error("namespaces should not be included in output")
+	}
+	if !strings.Contains(msg, "\"Kind\": \"work\"") {
+		t.Error("work resources should be included in output")
+	}
+	if !strings.Contains(msg, "\"Kind\": \"education\"") {
+		t.Error("education resources should be included in output")
+	}
+}
+
+// ---------------- ResourceService aggregate ----------------
 
 func TestResourceServiceImpl(t *testing.T) {
 	repo := repository.NewInMemoryRepository()

--- a/internal/ui/schema.go
+++ b/internal/ui/schema.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+
 	"github.com/TrianaLab/awasm-portfolio/internal/models"
 	"github.com/TrianaLab/awasm-portfolio/internal/models/types"
 )
@@ -12,371 +13,354 @@ type Schema struct {
 	Extractors []func(models.Resource) string
 }
 
-// GenerateSchemas creates schemas for all resource types dynamically
+// GenerateSchemas creates schemas for all resource types dynamically.
 func GenerateSchemas() map[string]Schema {
 	return map[string]Schema{
-		"namespace": {
-			Headers: []string{"NAME", "AGE"},
-			Extractors: []func(models.Resource) string{
-				func(r models.Resource) string { return r.GetName() },
-				func(r models.Resource) string { return calculateAge(r.GetCreationTimestamp()) },
-			},
+		"namespace":   namespaceSchema(),
+		"resume":      resumeSchema(),
+		"basics":      basicsSchema(),
+		"work":        workSchema(),
+		"volunteer":   volunteerSchema(),
+		"education":   educationSchema(),
+		"skill":       skillSchema(),
+		"language":    languageSchema(),
+		"project":     projectSchema(),
+		"publication": publicationSchema(),
+		"certificate": certificateSchema(),
+		"interest":    interestSchema(),
+		"award":       awardSchema(),
+		"default":     defaultSchema(),
+	}
+}
+
+// Per-type extractor wrappers. Each performs the type assertion and returns
+// "N/A" when the resource is not of the expected concrete type. Generics
+// cannot replace these because *T type assertions on an interface value are
+// not legal in Go.
+
+func resumeExtract(pick func(*types.Resume) string) func(models.Resource) string {
+	return func(r models.Resource) string {
+		if v, ok := r.(*types.Resume); ok {
+			return pick(v)
+		}
+		return "N/A"
+	}
+}
+
+func basicsExtract(pick func(*types.Basics) string) func(models.Resource) string {
+	return func(r models.Resource) string {
+		if v, ok := r.(*types.Basics); ok {
+			return pick(v)
+		}
+		return "N/A"
+	}
+}
+
+func workExtract(pick func(*types.Work) string) func(models.Resource) string {
+	return func(r models.Resource) string {
+		if v, ok := r.(*types.Work); ok {
+			return pick(v)
+		}
+		return "N/A"
+	}
+}
+
+func volunteerExtract(pick func(*types.Volunteer) string) func(models.Resource) string {
+	return func(r models.Resource) string {
+		if v, ok := r.(*types.Volunteer); ok {
+			return pick(v)
+		}
+		return "N/A"
+	}
+}
+
+func educationExtract(pick func(*types.Education) string) func(models.Resource) string {
+	return func(r models.Resource) string {
+		if v, ok := r.(*types.Education); ok {
+			return pick(v)
+		}
+		return "N/A"
+	}
+}
+
+func skillExtract(pick func(*types.Skill) string) func(models.Resource) string {
+	return func(r models.Resource) string {
+		if v, ok := r.(*types.Skill); ok {
+			return pick(v)
+		}
+		return "N/A"
+	}
+}
+
+func languageExtract(pick func(*types.Language) string) func(models.Resource) string {
+	return func(r models.Resource) string {
+		if v, ok := r.(*types.Language); ok {
+			return pick(v)
+		}
+		return "N/A"
+	}
+}
+
+func projectExtract(pick func(*types.Project) string) func(models.Resource) string {
+	return func(r models.Resource) string {
+		if v, ok := r.(*types.Project); ok {
+			return pick(v)
+		}
+		return "N/A"
+	}
+}
+
+func publicationExtract(pick func(*types.Publication) string) func(models.Resource) string {
+	return func(r models.Resource) string {
+		if v, ok := r.(*types.Publication); ok {
+			return pick(v)
+		}
+		return "N/A"
+	}
+}
+
+func certificateExtract(pick func(*types.Certificate) string) func(models.Resource) string {
+	return func(r models.Resource) string {
+		if v, ok := r.(*types.Certificate); ok {
+			return pick(v)
+		}
+		return "N/A"
+	}
+}
+
+func interestExtract(pick func(*types.Interest) string) func(models.Resource) string {
+	return func(r models.Resource) string {
+		if v, ok := r.(*types.Interest); ok {
+			return pick(v)
+		}
+		return "N/A"
+	}
+}
+
+func awardExtract(pick func(*types.Award) string) func(models.Resource) string {
+	return func(r models.Resource) string {
+		if v, ok := r.(*types.Award); ok {
+			return pick(v)
+		}
+		return "N/A"
+	}
+}
+
+func nameExtractor() func(models.Resource) string {
+	return func(r models.Resource) string { return r.GetName() }
+}
+
+func namespaceExtractor() func(models.Resource) string {
+	return func(r models.Resource) string { return r.GetNamespace() }
+}
+
+func ageExtractor() func(models.Resource) string {
+	return func(r models.Resource) string { return calculateAge(r.GetCreationTimestamp()) }
+}
+
+func namespaceSchema() Schema {
+	return Schema{
+		Headers: []string{"NAME", "AGE"},
+		Extractors: []func(models.Resource) string{
+			nameExtractor(),
+			ageExtractor(),
 		},
-		"resume": {
-			Headers: []string{"NAME", "NAMESPACE", "BASICS", "WORK", "VOLUNTEER", "EDUCATION", "AWARDS", "CERTIFICATES", "PUBLICATIONS", "SKILLS", "LANGUAGES", "INTERESTS", "REFERENCES", "PROJECTS", "AGE"},
-			Extractors: []func(models.Resource) string{
-				func(r models.Resource) string { return r.GetName() },
-				func(r models.Resource) string { return r.GetNamespace() },
-				func(r models.Resource) string {
-					if resume, ok := r.(*types.Resume); ok {
-						return resume.Basics.Name
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string {
-					if resume, ok := r.(*types.Resume); ok {
-						return fmt.Sprintf("%d", len(resume.Work))
-					}
-					return "0"
-				},
-				func(r models.Resource) string {
-					if resume, ok := r.(*types.Resume); ok {
-						return fmt.Sprintf("%d", len(resume.Volunteer))
-					}
-					return "0"
-				},
-				func(r models.Resource) string {
-					if resume, ok := r.(*types.Resume); ok {
-						return fmt.Sprintf("%d", len(resume.Education))
-					}
-					return "0"
-				},
-				func(r models.Resource) string {
-					if resume, ok := r.(*types.Resume); ok {
-						return fmt.Sprintf("%d", len(resume.Awards))
-					}
-					return "0"
-				},
-				func(r models.Resource) string {
-					if resume, ok := r.(*types.Resume); ok {
-						return fmt.Sprintf("%d", len(resume.Certificates))
-					}
-					return "0"
-				},
-				func(r models.Resource) string {
-					if resume, ok := r.(*types.Resume); ok {
-						return fmt.Sprintf("%d", len(resume.Publications))
-					}
-					return "0"
-				},
-				func(r models.Resource) string {
-					if resume, ok := r.(*types.Resume); ok {
-						return fmt.Sprintf("%d", len(resume.Skills))
-					}
-					return "0"
-				},
-				func(r models.Resource) string {
-					if resume, ok := r.(*types.Resume); ok {
-						return fmt.Sprintf("%d", len(resume.Languages))
-					}
-					return "0"
-				},
-				func(r models.Resource) string {
-					if resume, ok := r.(*types.Resume); ok {
-						return fmt.Sprintf("%d", len(resume.Interests))
-					}
-					return "0"
-				},
-				func(r models.Resource) string {
-					if resume, ok := r.(*types.Resume); ok {
-						return fmt.Sprintf("%d", len(resume.References))
-					}
-					return "0"
-				},
-				func(r models.Resource) string {
-					if resume, ok := r.(*types.Resume); ok {
-						return fmt.Sprintf("%d", len(resume.Projects))
-					}
-					return "0"
-				},
-				func(r models.Resource) string { return calculateAge(r.GetCreationTimestamp()) },
-			},
+	}
+}
+
+func defaultSchema() Schema {
+	return Schema{
+		Headers: []string{"NAME", "NAMESPACE", "AGE"},
+		Extractors: []func(models.Resource) string{
+			nameExtractor(),
+			namespaceExtractor(),
+			ageExtractor(),
 		},
-		"basics": {
-			Headers: []string{"NAME", "NAMESPACE", "FULL NAME", "LABEL", "EMAIL", "PHONE", "AGE"},
-			Extractors: []func(models.Resource) string{
-				func(r models.Resource) string { return r.GetName() },
-				func(r models.Resource) string { return r.GetNamespace() },
-				func(r models.Resource) string {
-					if basics, ok := r.(*types.Basics); ok {
-						return basics.FullName
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string {
-					if basics, ok := r.(*types.Basics); ok {
-						return basics.Label
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string {
-					if basics, ok := r.(*types.Basics); ok {
-						return basics.Email
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string {
-					if basics, ok := r.(*types.Basics); ok {
-						return basics.Phone
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string { return calculateAge(r.GetCreationTimestamp()) },
-			},
+	}
+}
+
+func resumeSchema() Schema {
+	count := func(pick func(*types.Resume) int) func(models.Resource) string {
+		return resumeExtract(func(r *types.Resume) string { return fmt.Sprintf("%d", pick(r)) })
+	}
+	return Schema{
+		Headers: []string{"NAME", "NAMESPACE", "BASICS", "WORK", "VOLUNTEER", "EDUCATION", "AWARDS", "CERTIFICATES", "PUBLICATIONS", "SKILLS", "LANGUAGES", "INTERESTS", "REFERENCES", "PROJECTS", "AGE"},
+		Extractors: []func(models.Resource) string{
+			nameExtractor(),
+			namespaceExtractor(),
+			resumeExtract(func(r *types.Resume) string { return r.Basics.Name }),
+			count(func(r *types.Resume) int { return len(r.Work) }),
+			count(func(r *types.Resume) int { return len(r.Volunteer) }),
+			count(func(r *types.Resume) int { return len(r.Education) }),
+			count(func(r *types.Resume) int { return len(r.Awards) }),
+			count(func(r *types.Resume) int { return len(r.Certificates) }),
+			count(func(r *types.Resume) int { return len(r.Publications) }),
+			count(func(r *types.Resume) int { return len(r.Skills) }),
+			count(func(r *types.Resume) int { return len(r.Languages) }),
+			count(func(r *types.Resume) int { return len(r.Interests) }),
+			count(func(r *types.Resume) int { return len(r.References) }),
+			count(func(r *types.Resume) int { return len(r.Projects) }),
+			ageExtractor(),
 		},
-		"work": {
-			Headers: []string{"NAME", "NAMESPACE", "COMPANY", "POSITION", "START", "END", "AGE"},
-			Extractors: []func(models.Resource) string{
-				func(r models.Resource) string { return r.GetName() },
-				func(r models.Resource) string { return r.GetNamespace() },
-				func(r models.Resource) string {
-					if work, ok := r.(*types.Work); ok {
-						return work.Company
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string {
-					if work, ok := r.(*types.Work); ok {
-						return work.Position
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string {
-					if work, ok := r.(*types.Work); ok {
-						return work.StartDate
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string {
-					if work, ok := r.(*types.Work); ok {
-						if work.EndDate == "" {
-							return "Present"
-						}
-						return work.EndDate
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string { return calculateAge(r.GetCreationTimestamp()) },
-			},
+	}
+}
+
+func basicsSchema() Schema {
+	return Schema{
+		Headers: []string{"NAME", "NAMESPACE", "FULL NAME", "LABEL", "EMAIL", "PHONE", "AGE"},
+		Extractors: []func(models.Resource) string{
+			nameExtractor(),
+			namespaceExtractor(),
+			basicsExtract(func(b *types.Basics) string { return b.FullName }),
+			basicsExtract(func(b *types.Basics) string { return b.Label }),
+			basicsExtract(func(b *types.Basics) string { return b.Email }),
+			basicsExtract(func(b *types.Basics) string { return b.Phone }),
+			ageExtractor(),
 		},
-		"volunteer": {
-			Headers: []string{"NAME", "NAMESPACE", "ORGANIZATION", "POSITION", "AGE"},
-			Extractors: []func(models.Resource) string{
-				func(r models.Resource) string { return r.GetName() },
-				func(r models.Resource) string { return r.GetNamespace() },
-				func(r models.Resource) string {
-					if vol, ok := r.(*types.Volunteer); ok {
-						return vol.Organization
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string {
-					if vol, ok := r.(*types.Volunteer); ok {
-						return vol.Position
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string { return calculateAge(r.GetCreationTimestamp()) },
-			},
+	}
+}
+
+func workSchema() Schema {
+	return Schema{
+		Headers: []string{"NAME", "NAMESPACE", "COMPANY", "POSITION", "START", "END", "AGE"},
+		Extractors: []func(models.Resource) string{
+			nameExtractor(),
+			namespaceExtractor(),
+			workExtract(func(w *types.Work) string { return w.Company }),
+			workExtract(func(w *types.Work) string { return w.Position }),
+			workExtract(func(w *types.Work) string { return w.StartDate }),
+			workExtract(func(w *types.Work) string {
+				if w.EndDate == "" {
+					return "Present"
+				}
+				return w.EndDate
+			}),
+			ageExtractor(),
 		},
-		"education": {
-			Headers: []string{"NAME", "NAMESPACE", "INSTITUTION", "AREA", "STUDY TYPE", "AGE"},
-			Extractors: []func(models.Resource) string{
-				func(r models.Resource) string { return r.GetName() },
-				func(r models.Resource) string { return r.GetNamespace() },
-				func(r models.Resource) string {
-					if edu, ok := r.(*types.Education); ok {
-						return edu.Institution
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string {
-					if edu, ok := r.(*types.Education); ok {
-						return edu.Area
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string {
-					if edu, ok := r.(*types.Education); ok {
-						return edu.StudyType
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string { return calculateAge(r.GetCreationTimestamp()) },
-			},
+	}
+}
+
+func volunteerSchema() Schema {
+	return Schema{
+		Headers: []string{"NAME", "NAMESPACE", "ORGANIZATION", "POSITION", "AGE"},
+		Extractors: []func(models.Resource) string{
+			nameExtractor(),
+			namespaceExtractor(),
+			volunteerExtract(func(v *types.Volunteer) string { return v.Organization }),
+			volunteerExtract(func(v *types.Volunteer) string { return v.Position }),
+			ageExtractor(),
 		},
-		"skill": {
-			Headers: []string{"NAME", "NAMESPACE", "SKILL", "LEVEL", "KEYWORDS", "AGE"},
-			Extractors: []func(models.Resource) string{
-				func(r models.Resource) string { return r.GetName() },
-				func(r models.Resource) string { return r.GetNamespace() },
-				func(r models.Resource) string {
-					if skill, ok := r.(*types.Skill); ok {
-						return skill.Skill
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string {
-					if skill, ok := r.(*types.Skill); ok {
-						return skill.Level
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string {
-					if skill, ok := r.(*types.Skill); ok {
-						if len(skill.Keywords) > 3 {
-							return fmt.Sprintf("%s, ...", skill.Keywords[0:3])
-						}
-						return fmt.Sprintf("%v", skill.Keywords)
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string { return calculateAge(r.GetCreationTimestamp()) },
-			},
+	}
+}
+
+func educationSchema() Schema {
+	return Schema{
+		Headers: []string{"NAME", "NAMESPACE", "INSTITUTION", "AREA", "STUDY TYPE", "AGE"},
+		Extractors: []func(models.Resource) string{
+			nameExtractor(),
+			namespaceExtractor(),
+			educationExtract(func(e *types.Education) string { return e.Institution }),
+			educationExtract(func(e *types.Education) string { return e.Area }),
+			educationExtract(func(e *types.Education) string { return e.StudyType }),
+			ageExtractor(),
 		},
-		"language": {
-			Headers: []string{"NAME", "NAMESPACE", "LANGUAGE", "FLUENCY", "AGE"},
-			Extractors: []func(models.Resource) string{
-				func(r models.Resource) string { return r.GetName() },
-				func(r models.Resource) string { return r.GetNamespace() },
-				func(r models.Resource) string {
-					if lang, ok := r.(*types.Language); ok {
-						return lang.Language
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string {
-					if lang, ok := r.(*types.Language); ok {
-						return lang.Fluency
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string { return calculateAge(r.GetCreationTimestamp()) },
-			},
+	}
+}
+
+func skillSchema() Schema {
+	return Schema{
+		Headers: []string{"NAME", "NAMESPACE", "SKILL", "LEVEL", "KEYWORDS", "AGE"},
+		Extractors: []func(models.Resource) string{
+			nameExtractor(),
+			namespaceExtractor(),
+			skillExtract(func(s *types.Skill) string { return s.Skill }),
+			skillExtract(func(s *types.Skill) string { return s.Level }),
+			skillExtract(func(s *types.Skill) string {
+				if len(s.Keywords) > 3 {
+					return fmt.Sprintf("%s, ...", s.Keywords[0:3])
+				}
+				return fmt.Sprintf("%v", s.Keywords)
+			}),
+			ageExtractor(),
 		},
-		"project": {
-			Headers: []string{"NAME", "NAMESPACE", "PROJECT", "URL", "AGE"},
-			Extractors: []func(models.Resource) string{
-				func(r models.Resource) string { return r.GetName() },
-				func(r models.Resource) string { return r.GetNamespace() },
-				func(r models.Resource) string {
-					if proj, ok := r.(*types.Project); ok {
-						return proj.Project
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string {
-					if proj, ok := r.(*types.Project); ok {
-						return proj.URL
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string { return calculateAge(r.GetCreationTimestamp()) },
-			},
+	}
+}
+
+func languageSchema() Schema {
+	return Schema{
+		Headers: []string{"NAME", "NAMESPACE", "LANGUAGE", "FLUENCY", "AGE"},
+		Extractors: []func(models.Resource) string{
+			nameExtractor(),
+			namespaceExtractor(),
+			languageExtract(func(l *types.Language) string { return l.Language }),
+			languageExtract(func(l *types.Language) string { return l.Fluency }),
+			ageExtractor(),
 		},
-		"publication": {
-			Headers: []string{"NAME", "NAMESPACE", "PUBLICATION", "PUBLISHER", "AGE"},
-			Extractors: []func(models.Resource) string{
-				func(r models.Resource) string { return r.GetName() },
-				func(r models.Resource) string { return r.GetNamespace() },
-				func(r models.Resource) string {
-					if pub, ok := r.(*types.Publication); ok {
-						return pub.Publication
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string {
-					if pub, ok := r.(*types.Publication); ok {
-						return pub.Publisher
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string { return calculateAge(r.GetCreationTimestamp()) },
-			},
+	}
+}
+
+func projectSchema() Schema {
+	return Schema{
+		Headers: []string{"NAME", "NAMESPACE", "PROJECT", "URL", "AGE"},
+		Extractors: []func(models.Resource) string{
+			nameExtractor(),
+			namespaceExtractor(),
+			projectExtract(func(p *types.Project) string { return p.Project }),
+			projectExtract(func(p *types.Project) string { return p.URL }),
+			ageExtractor(),
 		},
-		"certificate": {
-			Headers: []string{"NAME", "NAMESPACE", "CERTIFICATE", "DATE", "ISSUER", "AGE"},
-			Extractors: []func(models.Resource) string{
-				func(r models.Resource) string { return r.GetName() },
-				func(r models.Resource) string { return r.GetNamespace() },
-				func(r models.Resource) string {
-					if certificate, ok := r.(*types.Certificate); ok {
-						return certificate.Certificate
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string {
-					if certificate, ok := r.(*types.Certificate); ok {
-						return certificate.Date
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string {
-					if certificate, ok := r.(*types.Certificate); ok {
-						return certificate.Issuer
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string { return calculateAge(r.GetCreationTimestamp()) },
-			},
+	}
+}
+
+func publicationSchema() Schema {
+	return Schema{
+		Headers: []string{"NAME", "NAMESPACE", "PUBLICATION", "PUBLISHER", "AGE"},
+		Extractors: []func(models.Resource) string{
+			nameExtractor(),
+			namespaceExtractor(),
+			publicationExtract(func(p *types.Publication) string { return p.Publication }),
+			publicationExtract(func(p *types.Publication) string { return p.Publisher }),
+			ageExtractor(),
 		},
-		"interest": {
-			Headers: []string{"NAME", "NAMESPACE", "INTEREST", "AGE"},
-			Extractors: []func(models.Resource) string{
-				func(r models.Resource) string { return r.GetName() },
-				func(r models.Resource) string { return r.GetNamespace() },
-				func(r models.Resource) string {
-					if interest, ok := r.(*types.Interest); ok {
-						return interest.Interest
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string { return calculateAge(r.GetCreationTimestamp()) },
-			},
+	}
+}
+
+func certificateSchema() Schema {
+	return Schema{
+		Headers: []string{"NAME", "NAMESPACE", "CERTIFICATE", "DATE", "ISSUER", "AGE"},
+		Extractors: []func(models.Resource) string{
+			nameExtractor(),
+			namespaceExtractor(),
+			certificateExtract(func(c *types.Certificate) string { return c.Certificate }),
+			certificateExtract(func(c *types.Certificate) string { return c.Date }),
+			certificateExtract(func(c *types.Certificate) string { return c.Issuer }),
+			ageExtractor(),
 		},
-		"award": {
-			Headers: []string{"NAME", "NAMESPACE", "TITLE", "AWARDER", "DATE", "AGE"},
-			Extractors: []func(models.Resource) string{
-				func(r models.Resource) string { return r.GetName() },
-				func(r models.Resource) string { return r.GetNamespace() },
-				func(r models.Resource) string {
-					if award, ok := r.(*types.Award); ok {
-						return award.Title
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string {
-					if award, ok := r.(*types.Award); ok {
-						return award.Awarder
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string {
-					if award, ok := r.(*types.Award); ok {
-						return award.Date
-					}
-					return "N/A"
-				},
-				func(r models.Resource) string { return calculateAge(r.GetCreationTimestamp()) },
-			},
+	}
+}
+
+func interestSchema() Schema {
+	return Schema{
+		Headers: []string{"NAME", "NAMESPACE", "INTEREST", "AGE"},
+		Extractors: []func(models.Resource) string{
+			nameExtractor(),
+			namespaceExtractor(),
+			interestExtract(func(i *types.Interest) string { return i.Interest }),
+			ageExtractor(),
 		},
-		"default": {
-			Headers: []string{"NAME", "NAMESPACE", "AGE"},
-			Extractors: []func(models.Resource) string{
-				func(r models.Resource) string { return r.GetName() },
-				func(r models.Resource) string { return r.GetNamespace() },
-				func(r models.Resource) string { return calculateAge(r.GetCreationTimestamp()) },
-			},
+	}
+}
+
+func awardSchema() Schema {
+	return Schema{
+		Headers: []string{"NAME", "NAMESPACE", "TITLE", "AWARDER", "DATE", "AGE"},
+		Extractors: []func(models.Resource) string{
+			nameExtractor(),
+			namespaceExtractor(),
+			awardExtract(func(a *types.Award) string { return a.Title }),
+			awardExtract(func(a *types.Award) string { return a.Awarder }),
+			awardExtract(func(a *types.Award) string { return a.Date }),
+			ageExtractor(),
 		},
 	}
 }

--- a/internal/util/resource_util_test.go
+++ b/internal/util/resource_util_test.go
@@ -8,7 +8,7 @@ import (
 func TestSupportedResources(t *testing.T) {
 	resources := util.SupportedResources()
 
-	// Verificar que algunos recursos clave están presentes
+	// Verify that some key resources are present
 	expectedResources := map[string]string{
 		"resume":      "resume",
 		"resumes":     "resume",


### PR DESCRIPTION
## Summary

Brings Go Report Card grade from **A+ with warnings** to clean A+ by enforcing pacto-level strictness:

- **gocyclo ≤ 15 everywhere** (no test-file ignore, no schema.go ignore)
- **misspell** added to golangci-lint with a single ignore for the proper noun *Internacional*
- **Release chain fix**: future auto-releases now actually publish artifacts and deploy Pages

## Changes

**gocyclo**
- `internal/ui/schema.go`: `GenerateSchemas` 44 → 14 by splitting into per-kind functions and typed `xxxExtract(...)` wrappers
- `internal/service/service_test.go`: TestDeleteService (37), TestCreateService (27), TestDescribeService (20) split into focused top-level tests with `newDeleteServiceFixture` / `newCreateServiceFixture` / `newDescribeServiceFixture` / `newGetServiceFixture` helpers + `mustCreate` / `assertErrContains` assertions
- `internal/repository/in_memory_repository_test.go`: TestInMemoryRepository (25) split likewise with `newRepoWithResume`
- `ci.mk`: drop the `_test.go` + `schema.go` ignore from `ci-cyclo`

**misspell**
- Add `.golangci.yml` with `misspell` linter enabled (locale: US, ignore: `Internacional` for the Spanish university name)
- Translate Spanish comment `Verificar... presentes` → `Verify... are present`

**Release event chain**
- `release.yml` + `cd.yml`: add `workflow_run` trigger on the `Auto release` workflow so they fire after auto-release completes (works around the GitHub limitation that GITHUB_TOKEN-created releases don't emit release events)
- Add `workflow_dispatch` with a tag input for manual re-runs
- Resolve tag from `release.tag_name`, `workflow_dispatch.inputs.tag`, or the latest release

## Test plan

- [x] `make ci` passes locally — fmt, vet, gocyclo ≤15, golangci-lint (with misspell), 100% coverage
- [ ] CI green (`static`, `unit-test`, `validate`)
- [ ] Next auto-release should now produce GHCR image + Pages deploy + release tarball (visible under Actions immediately after the auto-release run)