### PR TITLE
fix(docker): build WASM and UI stages on BUILDPLATFORM to avoid arm64 SIGILL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # ── Stage 1: build the Go WASM artifact ─────────────────────────────────
-FROM golang:1.26.0 AS wasm-builder
+# Pin to BUILDPLATFORM: the output is a portable .wasm file, so we avoid
+# slow (and SIGILL-prone) QEMU emulation when building for linux/arm64.
+FROM --platform=$BUILDPLATFORM golang:1.26.0 AS wasm-builder
 
 ARG VERSION=dev
 ARG GIT_COMMIT=unknown
@@ -17,7 +19,9 @@ COPY . .
 RUN make wasm VERSION=${VERSION}
 
 # ── Stage 2: build the Svelte + Vite frontend ──────────────────────────
-FROM node:22-alpine AS ui-builder
+# Pin to BUILDPLATFORM: Vite produces static assets, and running npm/node
+# under QEMU for linux/arm64 fails with SIGILL (exit 132).
+FROM --platform=$BUILDPLATFORM node:22-alpine AS ui-builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- The `Deploy to GitHub Pages and GHCR` workflow has been failing on `docker` job ([run 26105912865](https://github.com/TrianaLab/awasm-portfolio/actions/runs/26105912865/job/76769569908)) with `exit code 132` (SIGILL) during `npm ci && npm run build` while buildx emulates `linux/arm64` via QEMU — a known issue where Node.js segfaults under emulation.
- Pin the `wasm-builder` and `ui-builder` stages to `--platform=$BUILDPLATFORM` so they run natively. Their outputs (`app.wasm`, static Vite bundle) are architecture-independent, so the final multi-arch image is unchanged. Only the final `nginx:stable-alpine` stage stays per-target-platform.

## Test plan
- [ ] CI green for the multi-arch (`linux/amd64,linux/arm64`) buildx step on this PR's run.
- [ ] After merge, re-trigger the `Deploy to GitHub Pages and GHCR` workflow for `v2.0.0` and confirm the `ghcr.io/trianalab/awasm-portfolio:v2.0.0` image is published for both architectures.
- [ ] Pull and run the published arm64 image (`docker run --rm -p 8080:80 --platform linux/arm64 ghcr.io/trianalab/awasm-portfolio:v2.0.0`) and load the portfolio in a browser to confirm the bundle works end-to-end.