### PR TITLE
feat: tab completion, responsive window UX, ATS-clean PDF, refreshed resume

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -270,6 +270,108 @@ func TestGetCommand_ServiceError(t *testing.T) {
 	}
 }
 
+// ─── Tab completion (__complete) ──────────────────────────────────────
+// These tests drive Cobra's hidden __complete subcommand to exercise
+// every branch of the ValidArgsFunction wiring used by the browser
+// terminal. Cobra's __complete output is "candidate\tdescription\n…"
+// followed by a ":<directive>" trailer; we just assert substrings.
+
+func TestCompleteCommand_Subcommands(t *testing.T) {
+	repo := repository.NewInMemoryRepository()
+	rootCmd := cmd.NewRootCommand(repo)
+
+	output, _ := setupTestCommand(t, rootCmd, []string{"__complete", ""})
+	for _, want := range []string{"create", "delete", "describe", "get", "version"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("expected %q in subcommand completion, got: %s", want, output)
+		}
+	}
+}
+
+func TestCompleteCommand_GetKinds(t *testing.T) {
+	repo := repository.NewInMemoryRepository()
+	rootCmd := cmd.NewRootCommand(repo)
+
+	output, _ := setupTestCommand(t, rootCmd, []string{"__complete", "get", ""})
+	for _, want := range []string{"namespace", "work", "resume", "all"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("expected %q in get kind completion, got: %s", want, output)
+		}
+	}
+}
+
+func TestCompleteCommand_GetNames(t *testing.T) {
+	repo := repository.NewInMemoryRepository()
+	rootCmd := cmd.NewRootCommand(repo)
+	_, _ = setupTestCommand(t, rootCmd, []string{"create", "namespace", "testns"})
+
+	output, _ := setupTestCommand(t, rootCmd, []string{"__complete", "get", "namespace", ""})
+	if !strings.Contains(output, "testns") {
+		t.Errorf("expected 'testns' in name completion, got: %s", output)
+	}
+}
+
+func TestCompleteCommand_GetNamesInvalidKind(t *testing.T) {
+	repo := repository.NewInMemoryRepository()
+	rootCmd := cmd.NewRootCommand(repo)
+
+	// Invalid kind must yield no name candidates (resourceNamesFor's
+	// error path returns nil; Cobra reports an empty completion list).
+	output, _ := setupTestCommand(t, rootCmd, []string{"__complete", "get", "notakind", ""})
+	if strings.Contains(output, "panic") {
+		t.Errorf("unexpected panic on invalid kind, got: %s", output)
+	}
+}
+
+func TestCompleteCommand_GetBeyondTwoArgs(t *testing.T) {
+	repo := repository.NewInMemoryRepository()
+	rootCmd := cmd.NewRootCommand(repo)
+
+	// Third positional is past what completeResourceArgs covers — the
+	// default switch branch must return cleanly with no candidates.
+	output, _ := setupTestCommand(t, rootCmd, []string{"__complete", "get", "namespace", "default", ""})
+	if strings.Contains(output, "panic") {
+		t.Errorf("unexpected panic past valid arg count, got: %s", output)
+	}
+}
+
+func TestCompleteCommand_DescribeKinds(t *testing.T) {
+	repo := repository.NewInMemoryRepository()
+	rootCmd := cmd.NewRootCommand(repo)
+
+	output, _ := setupTestCommand(t, rootCmd, []string{"__complete", "describe", ""})
+	if !strings.Contains(output, "namespace") {
+		t.Errorf("expected describe to suggest kinds, got: %s", output)
+	}
+}
+
+func TestCompleteCommand_DeleteKinds(t *testing.T) {
+	repo := repository.NewInMemoryRepository()
+	rootCmd := cmd.NewRootCommand(repo)
+
+	output, _ := setupTestCommand(t, rootCmd, []string{"__complete", "delete", ""})
+	if !strings.Contains(output, "namespace") {
+		t.Errorf("expected delete to suggest kinds, got: %s", output)
+	}
+}
+
+func TestCompleteCommand_CreateKinds(t *testing.T) {
+	repo := repository.NewInMemoryRepository()
+	rootCmd := cmd.NewRootCommand(repo)
+
+	// create's ValidArgsFunction returns kinds for the first positional…
+	output, _ := setupTestCommand(t, rootCmd, []string{"__complete", "create", ""})
+	if !strings.Contains(output, "namespace") {
+		t.Errorf("expected create to suggest kinds, got: %s", output)
+	}
+
+	// …and nothing for the second (it's a free-form name).
+	output, _ = setupTestCommand(t, rootCmd, []string{"__complete", "create", "namespace", ""})
+	if strings.Contains(output, "panic") {
+		t.Errorf("unexpected panic completing create's second arg, got: %s", output)
+	}
+}
+
 func TestRootCommand_HelpFlag(t *testing.T) {
 	repo := repository.NewInMemoryRepository()
 	rootCmd := cmd.NewRootCommand(repo)

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -13,6 +13,12 @@ func NewCreateCommand(repo *repository.InMemoryRepository) *cobra.Command {
 		Short:         "Create a new resource",
 		SilenceErrors: false,
 		Args:          cobra.ExactArgs(2),
+		ValidArgsFunction: func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+			if len(args) == 0 {
+				return canonicalResourceKinds(), cobra.ShellCompDirectiveNoFileComp
+			}
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
 		Example: `
 # Create a namespace
 kubectl create namespace dev

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -9,9 +9,10 @@ import (
 
 func NewDeleteCommand(repo *repository.InMemoryRepository) *cobra.Command {
 	return &cobra.Command{
-		Use:   "delete [kind] [name]",
-		Short: "Delete a resource",
-		Args:  cobra.ExactArgs(2),
+		Use:               "delete [kind] [name]",
+		Short:             "Delete a resource",
+		Args:              cobra.ExactArgs(2),
+		ValidArgsFunction: completeResourceArgs(repo),
 		Example: `
 # Delete the profile john-doe in the dev namespace
 kubectl delete profile john-doe -n dev

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -9,9 +9,10 @@ import (
 
 func NewDescribeCommand(repo *repository.InMemoryRepository) *cobra.Command {
 	return &cobra.Command{
-		Use:   "describe [kind] [name]",
-		Short: "Describe a specific resource",
-		Args:  cobra.RangeArgs(0, 2),
+		Use:               "describe [kind] [name]",
+		Short:             "Describe a specific resource",
+		Args:              cobra.RangeArgs(0, 2),
+		ValidArgsFunction: completeResourceArgs(repo),
 		Example: `
 # Describe the profile john-doe in the dev namespace
 kubectl describe profile john-doe -n dev

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -11,9 +11,10 @@ import (
 
 func NewGetCommand(repo *repository.InMemoryRepository) *cobra.Command {
 	return &cobra.Command{
-		Use:   "get [kind] [name]",
-		Short: "Get resources of a specific kind or a specific resource",
-		Args:  cobra.RangeArgs(0, 2),
+		Use:               "get [kind] [name]",
+		Short:             "Get resources of a specific kind or a specific resource",
+		Args:              cobra.RangeArgs(0, 2),
+		ValidArgsFunction: completeResourceArgs(repo),
 		Example: `
 # Get all profiles in the default namespace
 kubectl get profile

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/TrianaLab/awasm-portfolio/internal/repository"
 	"github.com/TrianaLab/awasm-portfolio/internal/util"
@@ -70,6 +71,63 @@ func rootHelp(cmd *cobra.Command, _ []string) {
 	cmd.Println("  -h, --help               help for kubectl")
 	cmd.Println("  -n, --namespace string   Specify the namespace (default \"default\")")
 	cmd.Println("\nUse \"kubectl [command] --help\" for more information about a command.")
+}
+
+// canonicalResourceKinds returns the de-duplicated, sorted list of
+// resource kinds, plus the "all" pseudo-kind, suitable for shell tab
+// completion. Aliases are intentionally excluded — they would otherwise
+// triple the candidate list and add noise.
+func canonicalResourceKinds() []string {
+	seen := map[string]struct{}{}
+	for _, canonical := range util.SupportedResources() {
+		seen[canonical] = struct{}{}
+	}
+	out := make([]string, 0, len(seen)+1)
+	for k := range seen {
+		out = append(out, k)
+	}
+	out = append(out, "all")
+	sort.Strings(out)
+	return out
+}
+
+// resourceNamesFor returns the deduplicated names of resources of the
+// given kind in the active namespace context, used for completing the
+// second positional argument of get/describe/delete. Dedup matters
+// when the cmd context is -A (all namespaces): the same resource name
+// can exist in multiple namespaces.
+func resourceNamesFor(repo *repository.InMemoryRepository, kind string, namespace string) []string {
+	resources, err := repo.List(kind, "", namespace)
+	if err != nil {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	for _, r := range resources {
+		seen[r.GetName()] = struct{}{}
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// completeResourceArgs is the ValidArgsFunction shared by
+// get/describe/delete: the first positional completes resource kinds,
+// the second completes existing resource names of that kind.
+func completeResourceArgs(repo *repository.InMemoryRepository) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+		switch len(args) {
+		case 0:
+			return canonicalResourceKinds(), cobra.ShellCompDirectiveNoFileComp
+		case 1:
+			flags := readFlags(cmd)
+			return resourceNamesFor(repo, args[0], flags.namespace), cobra.ShellCompDirectiveNoFileComp
+		default:
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+	}
 }
 
 // flagContext collects the persistent flag values commands care about.

--- a/frontend/e2e/pdf-ats.spec.ts
+++ b/frontend/e2e/pdf-ats.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from '@playwright/test';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Asserts the actual rendered PDF — as an ATS reader sees it — keeps
+// the resume content in a parseable order. The browser produces the
+// PDF, playwright captures the download, then we shell out to pypdf
+// for the text extraction (the same approach an ATS pipeline uses).
+//
+// pypdf is checked at startup; missing tooling skips the spec rather
+// than failing the suite, so developers without the Python dep can
+// still run the rest of e2e.
+
+function extractPdfText(pdfPath: string): string | null {
+  try {
+    return execFileSync(
+      'python3',
+      ['-c', `import sys, pypdf; r = pypdf.PdfReader(sys.argv[1]); print('\\n'.join(p.extract_text() for p in r.pages))`, pdfPath],
+      { encoding: 'utf8' },
+    );
+  } catch {
+    return null;
+  }
+}
+
+test.describe('PDF ATS extraction', () => {
+  test('downloaded PDF extracts to clean linear text in expected order', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('.xterm')).toBeVisible({ timeout: 10_000 });
+
+    const [download] = await Promise.all([
+      page.waitForEvent('download', { timeout: 30_000 }),
+      page.getByRole('button', { name: /download resume as pdf/i }).click(),
+    ]);
+
+    const dir = mkdtempSync(join(tmpdir(), 'resume-pdf-'));
+    const path = join(dir, 'resume.pdf');
+    await download.saveAs(path);
+    expect(existsSync(path), 'PDF must be written to disk').toBe(true);
+
+    const text = extractPdfText(path);
+    if (text === null) {
+      test.skip(true, 'pypdf not installed (pip install pypdf) — skipping ATS extraction check');
+      return;
+    }
+
+    // Write the extracted text alongside the PDF so a failing run can be
+    // inspected from the test output directory.
+    writeFileSync(join(dir, 'extracted.txt'), text);
+
+    // ── ATS-critical fields ─────────────────────────────────────────
+    // Name and label must appear first (every ATS uses them to seed the
+    // candidate record).
+    expect(text).toMatch(/Eduardo D[íi]az/);
+    expect(text).toContain('Platform Engineer');
+
+    // Contact basics must extract as raw, parseable strings — not
+    // glyph-mashed clusters.
+    expect(text).toContain('edudiazasencio@gmail.com');
+    expect(text).toContain('+34 622287557');
+    expect(text).toContain('edudiaz.dev');
+
+    // Section ordering — Experience must come before Education must
+    // come before Skills. ATSs that bucket by section rely on this.
+    const idxExperience = text.indexOf('EXPERIENCE');
+    const idxEducation = text.indexOf('EDUCATION');
+    const idxSkills = text.indexOf('SKILLS');
+    expect(idxExperience).toBeGreaterThan(-1);
+    expect(idxEducation).toBeGreaterThan(idxExperience);
+    expect(idxSkills).toBeGreaterThan(idxEducation);
+
+    // Dates must extract with the ASCII hyphen — the "→" arrow gets
+    // dropped by some readers and collapses ranges to "Feb 2024Jul 2024".
+    expect(text).not.toContain('→');
+    expect(text).toMatch(/\b\w{3,9}\s+\d{4}\s+-\s+(Present|\w{3,9}\s+\d{4})/);
+
+    // The skills section must not interleave a skill's name with another
+    // skill's keywords — i.e. the keyword line must immediately follow
+    // its label. Checking one representative pair: Kubernetes belongs
+    // under "Kubernetes and Cloud-Native".
+    const labelIdx = text.indexOf('Kubernetes and Cloud-Native');
+    expect(labelIdx).toBeGreaterThan(-1);
+    const k8sIdx = text.indexOf('Kubernetes', labelIdx + 'Kubernetes and Cloud-Native'.length);
+    expect(k8sIdx).toBeGreaterThan(labelIdx);
+    // No other "Skill: " header should sneak between the label and its keywords.
+    const interloper = text.slice(labelIdx + 'Kubernetes and Cloud-Native'.length, k8sIdx);
+    expect(interloper).not.toMatch(/Cloud Platforms|Observability|Platform Engineering/);
+  });
+});

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -192,13 +192,17 @@ test.describe('awasm-portfolio smoke', () => {
     const chrome = win.locator('.chrome');
     await chrome.click({ position: { x: 300, y: 10 } });
     await chrome.click({ position: { x: 300, y: 10 } });
-    await page.waitForTimeout(150);
+    // 250 ms covers the 180 ms maximize/snap CSS transition plus a small
+    // jitter buffer; boundingBox() reads the in-flight value mid-anim.
+    await page.waitForTimeout(250);
     let now = await win.boundingBox();
     expect(Math.abs(now!.width - desktop!.width)).toBeLessThan(3);
 
     await chrome.click({ position: { x: 300, y: 10 } });
     await chrome.click({ position: { x: 300, y: 10 } });
-    await page.waitForTimeout(150);
+    // 250 ms covers the 180 ms maximize/snap CSS transition plus a small
+    // jitter buffer; boundingBox() reads the in-flight value mid-anim.
+    await page.waitForTimeout(250);
     now = await win.boundingBox();
     expect(Math.abs(now!.width - before!.width)).toBeLessThan(3);
   });
@@ -260,13 +264,13 @@ test.describe('awasm-portfolio smoke', () => {
     expect(before!.width).toBeLessThan(desktop!.width);
 
     await win.getByRole('button', { name: /maximize window/i }).click();
-    await page.waitForTimeout(150);
+    await page.waitForTimeout(250);
     const max = await win.boundingBox();
     expect(Math.abs(max!.width - desktop!.width)).toBeLessThan(3);
     expect(Math.abs(max!.height - desktop!.height)).toBeLessThan(3);
 
     await win.getByRole('button', { name: /maximize window/i }).click();
-    await page.waitForTimeout(150);
+    await page.waitForTimeout(250);
     const restored = await win.boundingBox();
     expect(Math.abs(restored!.width - before!.width)).toBeLessThan(3);
     expect(Math.abs(restored!.height - before!.height)).toBeLessThan(3);
@@ -318,6 +322,57 @@ test.describe('awasm-portfolio smoke', () => {
       return dialog.getBoundingClientRect().bottom - xterm.getBoundingClientRect().bottom;
     });
     expect(clearance, 'xterm canvas must finish inside the window').toBeGreaterThan(0);
+  });
+
+  test('window manager: dragging a snapped window restores its previous size', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto('/');
+    await expect(page.locator('.xterm')).toBeVisible({ timeout: 10_000 });
+
+    const win = page.locator('[role="dialog"]').first();
+    const before = await win.boundingBox();
+
+    // Maximize first (same code path as snap — both set previousGeometry).
+    await win.getByRole('button', { name: /maximize window/i }).click();
+    await page.waitForTimeout(200);
+    const maxed = await win.boundingBox();
+    expect(Math.abs(maxed!.width - 1280)).toBeLessThan(3);
+
+    // Now drag the chrome to "pull off" — window should restore to the
+    // original size and stay under the cursor.
+    const chrome = win.locator('.chrome');
+    const chromeBox = await chrome.boundingBox();
+    const startX = chromeBox!.x + 300;
+    const startY = chromeBox!.y + 12;
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(startX + 60, startY + 60, { steps: 8 });
+    await page.mouse.up();
+    await page.waitForTimeout(200);
+
+    const after = await win.boundingBox();
+    // Width must shrink back from maximized → roughly the pre-maximize size.
+    expect(Math.abs(after!.width - before!.width)).toBeLessThan(20);
+    expect(Math.abs(after!.height - before!.height)).toBeLessThan(20);
+  });
+
+  test('phone viewport: terminal fills the desktop', async ({ page }) => {
+    // iPhone-ish viewport. On phones the window forcibly fills the
+    // desktop area so the terminal is actually usable.
+    await page.setViewportSize({ width: 390, height: 780 });
+    await page.goto('/');
+    await expect(page.locator('.xterm')).toBeVisible({ timeout: 10_000 });
+
+    const win = page.locator('[role="dialog"]').first();
+    const desktop = await page.locator('.desktop').boundingBox();
+    const winBox = await win.boundingBox();
+    expect(desktop).not.toBeNull();
+    expect(winBox).not.toBeNull();
+    // Window must span the whole desktop area on phones.
+    expect(Math.abs(winBox!.width - desktop!.width)).toBeLessThan(3);
+    expect(Math.abs(winBox!.height - desktop!.height)).toBeLessThan(3);
+    // Resize handles must be hidden so they don't trap taps.
+    await expect(win.locator('.rz-se')).toBeHidden();
   });
 
   test('window manager: focus brings background window to front', async ({ page }) => {

--- a/frontend/e2e/tab-complete.spec.ts
+++ b/frontend/e2e/tab-complete.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from '@playwright/test';
+
+// Cross-cutting helpers ─ all tab-completion specs hit the same first
+// terminal and need a focused helper textarea to send keystrokes into.
+async function bootTerminal(page: import('@playwright/test').Page) {
+  await page.goto('/');
+  await expect(page.locator('.xterm')).toContainText('Welcome', { timeout: 10_000 });
+  const helper = page.locator('.xterm-helper-textarea').first();
+  await helper.focus();
+  return helper;
+}
+
+async function readVisibleTerminal(page: import('@playwright/test').Page): Promise<string> {
+  return page.evaluate(() => {
+    const rows = Array.from(document.querySelectorAll('.xterm-rows > div'));
+    return rows.map((r) => (r as HTMLElement).innerText).join('\n');
+  });
+}
+
+test.describe('terminal tab completion', () => {
+  test('single match: completes the subcommand and adds a space', async ({ page }) => {
+    await bootTerminal(page);
+    await page.keyboard.type('kubectl ge');
+    await page.keyboard.press('Tab');
+    await page.waitForTimeout(300);
+
+    const text = await readVisibleTerminal(page);
+    // Should have extended "ge" → "get" (with trailing space). The
+    // unfinished "kubectl ge" must no longer be present at end of line.
+    expect(text, `terminal:\n${text}`).toContain('kubectl get');
+    expect(text, `terminal:\n${text}`).not.toMatch(/kubectl ge$/m);
+  });
+
+  test('multiple matches: first Tab lists candidates and substitutes one', async ({ page }) => {
+    await bootTerminal(page);
+    // "de" matches both "describe" and "delete" — a single Tab should
+    // list candidates AND swap the first match into the buffer (cycle
+    // mode is now active).
+    await page.keyboard.type('kubectl de');
+    await page.keyboard.press('Tab');
+    await page.waitForTimeout(200);
+
+    const text = await readVisibleTerminal(page);
+    expect(text).toContain('delete');
+    expect(text).toContain('describe');
+  });
+
+  test('cycle: repeated Tab presses iterate through candidates', async ({ page }) => {
+    await bootTerminal(page);
+    await page.keyboard.type('kubectl de');
+    await page.keyboard.press('Tab');
+    await page.waitForTimeout(150);
+    await page.keyboard.press('Tab');
+    await page.waitForTimeout(150);
+
+    // After cycling, the prompt line should contain the SECOND
+    // candidate substituted in. Candidates are sorted alphabetically,
+    // so the order is "delete" → "describe".
+    const text = await readVisibleTerminal(page);
+    expect(text).toMatch(/kubectl describe/);
+  });
+
+  test('Enter while cycling commits and adds a space (does not submit)', async ({ page }) => {
+    await bootTerminal(page);
+    await page.keyboard.type('kubectl de');
+    await page.keyboard.press('Tab'); // enter cycle, "delete" substituted
+    await page.waitForTimeout(200); // let the async completion settle
+    await page.keyboard.press('Enter'); // commit + advance, NO submit
+    await page.waitForTimeout(150);
+
+    // Now type a name and submit a real command — proves the buffer
+    // wasn't sent on the cycle-Enter and that delete now has 2 args.
+    await page.keyboard.type('namespace default');
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(600);
+
+    const text = await readVisibleTerminal(page);
+    // The composed command ran (output contains "deleted"), and the
+    // cycle-Enter did NOT trigger a premature "unknown command" path.
+    expect(text).not.toMatch(/unknown command/);
+    expect(text).toMatch(/deleted/);
+  });
+
+  test('dynamic completion: resource kinds after `get `', async ({ page }) => {
+    await bootTerminal(page);
+    await page.keyboard.type('kubectl get ');
+    await page.keyboard.press('Tab');
+    await page.waitForTimeout(200);
+
+    const text = await readVisibleTerminal(page);
+    // At least one canonical resource kind should appear in the listing.
+    expect(text).toContain('namespace');
+  });
+
+  test('dynamic completion: resource names after `get namespace `', async ({ page }) => {
+    await bootTerminal(page);
+    // The preloaded data ships a "default" namespace among others; we
+    // want the second positional to be filled in by Tab.
+    await page.keyboard.type('kubectl get namespace ');
+    await page.keyboard.press('Tab');
+    await page.waitForTimeout(200);
+
+    const text = await readVisibleTerminal(page);
+    expect(text).toMatch(/kubectl get namespace \S+/);
+  });
+});

--- a/frontend/src/components/Desktop.svelte
+++ b/frontend/src/components/Desktop.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, tick } from 'svelte';
   import Window from './Window.svelte';
   import Terminal from './Terminal.svelte';
   import { createWindowManager } from '../lib/windows.svelte';
@@ -7,15 +7,26 @@
   const manager = createWindowManager();
   let desktopEl = $state<HTMLDivElement | null>(null);
 
-  onMount(() => {
-    // Open one terminal automatically so the user has something to look at.
+  function desktopSize(): { w: number; h: number } {
+    return {
+      w: desktopEl?.clientWidth ?? window.innerWidth,
+      h: desktopEl?.clientHeight ?? window.innerHeight,
+    };
+  }
+
+  onMount(async () => {
+    // Wait one tick so the desktop element is actually sized before we
+    // measure it — otherwise the first window opens against zeroes.
+    await tick();
     if (manager.windows.length === 0) {
-      manager.open('kubectl — terminal');
+      const { w, h } = desktopSize();
+      manager.open('kubectl — terminal', w, h);
     }
   });
 
   function openTerminal() {
-    manager.open(`kubectl — terminal #${manager.windows.length + 1}`);
+    const { w, h } = desktopSize();
+    manager.open(`kubectl — terminal #${manager.windows.length + 1}`, w, h);
   }
 
   export function open() {

--- a/frontend/src/components/Terminal.svelte
+++ b/frontend/src/components/Terminal.svelte
@@ -1,8 +1,15 @@
+<script module lang="ts">
+  // Module-scoped so the auto-typed welcome demo runs exactly once per
+  // page load — subsequent terminals opened via the "+" button (or
+  // re-mounted after a mode switch) skip the demo.
+  let demoHasRun = false;
+</script>
+
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
   import { Terminal } from '@xterm/xterm';
   import { FitAddon } from '@xterm/addon-fit';
-  import { runCommand } from '../lib/wasm';
+  import { runCommand, completeLine } from '../lib/wasm';
   import '@xterm/xterm/css/xterm.css';
 
   let container: HTMLDivElement;
@@ -11,21 +18,31 @@
   let resizeObserver: ResizeObserver | null = null;
 
   const PROMPT = '\x1b[32medudiaz.dev\x1b[0m\x1b[34m$\x1b[0m ';
+  // Color codes used in WELCOME (kept short for readability):
+  //   \x1b[36m cyan (logo)   \x1b[33m yellow (callout)
+  //   \x1b[90m grey (hint)   \x1b[0m  reset
   const WELCOME = [
     '\x1b[36m  __ ___      ____ _ ___ _ __ ___    \x1b[0m',
     '\x1b[36m / _` \\ \\ /\\ / / _` / __| \'_ ` _ \\   \x1b[0m',
     '\x1b[36m| (_| |\\ V  V / (_| \\__ \\ | | | | |  \x1b[0m',
     '\x1b[36m \\__,_| \\_/\\_/ \\__,_|___/_| |_| |_|  \x1b[0m',
     '',
-    'Welcome — type \x1b[33mkubectl --help\x1b[0m to get started.',
+    '\x1b[90m# Welcome. Eduardo\'s resume, exposed as kubectl resources.\x1b[0m',
+    '\x1b[90m# Press Tab to discover commands, or just watch…\x1b[0m',
     '',
   ];
+  const DEMO_COMMAND = 'kubectl get all';
 
   let input = '';
   let cursor = 0;
   const history: string[] = [];
   let historyIndex = -1;
   let running = false;
+  // Auto-typed demo: when true, character input from the welcome demo
+  // loop is being written into `input`; the first user keystroke aborts
+  // the demo via `demoAbort`.
+  let demoActive = false;
+  let demoAbort: (() => void) | null = null;
 
   function write(s: string) {
     term.write(s);
@@ -69,10 +86,211 @@
     }
   }
 
+  // Active completion cycle (zsh/fish-style). When a Tab finds multiple
+  // candidates, we list them, substitute the first into the buffer, and
+  // keep this state so the next Tab swaps in the next candidate. Any
+  // edit that isn't another Tab cancels the cycle. Enter while cycling
+  // accepts the current selection and adds a space — it does NOT submit
+  // the line; the user can then Tab again at the next position.
+  type CycleState = {
+    candidates: string[];
+    index: number;
+    anchorStart: number;
+    anchorEnd: number;
+  };
+  let cycle: CycleState | null = null;
+  // True while a completion round-trip to the WASM worker is in flight.
+  // Used to ignore further keystrokes (Tab, Enter, printable) so the
+  // user can't race past the async boundary and accidentally submit
+  // the line they were about to complete.
+  let completing = false;
+
+  function currentWord(line: string, pos: number): string {
+    let start = pos;
+    while (start > 0 && line[start - 1] !== ' ') start -= 1;
+    return line.slice(start, pos);
+  }
+
+  function applyCycleSelection() {
+    if (!cycle) return;
+    const candidate = cycle.candidates[cycle.index];
+    input = input.slice(0, cycle.anchorStart) + candidate + input.slice(cycle.anchorEnd);
+    cycle.anchorEnd = cycle.anchorStart + candidate.length;
+    cursor = cycle.anchorEnd;
+    redrawInput();
+  }
+
+  function cancelCycle() {
+    cycle = null;
+  }
+
+  async function handleTab() {
+    // Cycling: each Tab swaps in the next candidate at the same anchor.
+    if (cycle) {
+      cycle.index = (cycle.index + 1) % cycle.candidates.length;
+      applyCycleSelection();
+      return;
+    }
+
+    // Cobra-side completion operates on "kubectl <args>", so feed it the
+    // full line (or the implicit `kubectl ` if the user hasn't typed it).
+    const lineForCompletion = input.length === 0 ? 'kubectl ' : input.slice(0, cursor);
+    let candidates: string[];
+    completing = true;
+    try {
+      candidates = await completeLine(lineForCompletion);
+    } catch {
+      completing = false;
+      return;
+    } finally {
+      completing = false;
+    }
+    if (candidates.length === 0) return;
+
+    const word = currentWord(input, cursor);
+    // Cobra returns candidates with the same prefix as the partial token
+    // (it does its own filtering), so each candidate already starts
+    // with `word`. Be defensive in case that ever changes.
+    const matching = candidates.filter((c) => c.startsWith(word));
+    const pool = (matching.length > 0 ? matching : candidates).slice().sort();
+
+    if (pool.length === 1) {
+      const insertion = pool[0].slice(word.length) + ' ';
+      input = input.slice(0, cursor) + insertion + input.slice(cursor);
+      cursor += insertion.length;
+      redrawInput();
+      return;
+    }
+
+    // Multiple candidates → list them once, then enter cycle mode at
+    // index 0. Subsequent Tabs advance the cycle; Enter commits.
+    term.write('\r\n' + formatCandidates(pool) + '\r\n' + PROMPT + input);
+    if (cursor < input.length) {
+      term.write(`\x1b[${input.length - cursor}D`);
+    }
+    cycle = {
+      candidates: pool,
+      index: 0,
+      anchorStart: cursor - word.length,
+      anchorEnd: cursor,
+    };
+    applyCycleSelection();
+  }
+
+  function commitCycleAndAdvance() {
+    // Accept the currently-selected candidate, add the separating
+    // space, drop the cycle, and stay on the prompt (do NOT submit).
+    // The user can Tab again at the new position.
+    cancelCycle();
+    input = input.slice(0, cursor) + ' ' + input.slice(cursor);
+    cursor += 1;
+    redrawInput();
+  }
+
+  // Plays the auto-typed welcome demo: types DEMO_COMMAND character by
+  // character with a touch of cadence variation, pauses briefly, then
+  // executes it. Resolves once finished or aborted. Aborts on the first
+  // user keystroke (handled in handleKey).
+  async function runWelcomeDemo() {
+    demoActive = true;
+    let aborted = false;
+    demoAbort = () => {
+      aborted = true;
+    };
+    const sleep = (ms: number) =>
+      new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+    for (const ch of DEMO_COMMAND) {
+      if (aborted) break;
+      input = input.slice(0, cursor) + ch + input.slice(cursor);
+      cursor += 1;
+      redrawInput();
+      await sleep(45 + Math.random() * 55);
+    }
+    if (!aborted) {
+      await sleep(450);
+    }
+    if (aborted) {
+      demoActive = false;
+      demoAbort = null;
+      return;
+    }
+    const line = input;
+    history.push(line);
+    historyIndex = history.length;
+    await execute(line);
+    demoActive = false;
+    demoAbort = null;
+    prompt();
+  }
+
+  function formatCandidates(items: string[]): string {
+    // Two-space gap, wrap at the terminal width (with a 40-col floor
+    // so very narrow phone viewports still produce readable rows).
+    const lines: string[] = [];
+    const wrap = Math.max(40, term?.cols ?? 80);
+    let row = '';
+    for (const item of items) {
+      const sep = row.length === 0 ? '' : '  ';
+      if (row.length + sep.length + item.length > wrap) {
+        lines.push(row);
+        row = item;
+      } else {
+        row += sep + item;
+      }
+    }
+    if (row.length > 0) lines.push(row);
+    return lines.join('\r\n');
+  }
+
   function handleKey({ key, domEvent }: { key: string; domEvent: KeyboardEvent }) {
     if (running) return;
+    // First user keystroke during the welcome demo aborts it: clear
+    // the partial demo command, then fall through so the keystroke
+    // itself is processed as the first character of the user's own
+    // input (otherwise it would be silently dropped, eating the first
+    // letter of whatever they meant to type).
+    // demoActive is set false synchronously here so subsequent
+    // keystrokes (which run before the async demo loop has finished
+    // its cleanup) skip this branch instead of re-clearing the input.
+    if (demoActive) {
+      demoActive = false;
+      demoAbort?.();
+      demoAbort = null;
+      input = '';
+      cursor = 0;
+      redrawInput();
+    }
+    // Drop keystrokes while a completion round-trip is pending so the
+    // user can't submit the line by hitting Enter before cycle state
+    // has had a chance to populate.
+    if (completing) {
+      domEvent.preventDefault();
+      return;
+    }
     const code = domEvent.keyCode;
     const ctrl = domEvent.ctrlKey;
+
+    if (code === 9) {
+      // Tab — completion (fresh or cycling). xterm's onKey already
+      // prevents the default focus-shift; we just consume it here.
+      domEvent.preventDefault();
+      void handleTab();
+      return;
+    }
+
+    // Enter while cycling commits the current selection and advances
+    // to the next position instead of submitting the line.
+    if (code === 13 && cycle) {
+      commitCycleAndAdvance();
+      return;
+    }
+
+    // Any other key while cycling cancels cycle state and falls through
+    // to the regular handler (so typing a character mid-cycle behaves
+    // normally — the currently-substituted candidate stays in place and
+    // the new character is inserted at the cursor).
+    if (cycle) cancelCycle();
 
     if (code === 13) {
       // Enter
@@ -189,6 +407,16 @@
         handlePaste(data);
       }
     });
+
+    // Welcome demo: type out a sample command after a short beat so the
+    // user can register the welcome message first. Runs once per page
+    // load — subsequent terminals skip it (the module-scoped flag).
+    if (!demoHasRun) {
+      demoHasRun = true;
+      setTimeout(() => {
+        void runWelcomeDemo();
+      }, 700);
+    }
 
     const updateTheme = () => {
       term.options.theme = themeColors();

--- a/frontend/src/components/Window.svelte
+++ b/frontend/src/components/Window.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import type { Snippet } from 'svelte';
   import type { WindowState, WindowManager } from '../lib/windows.svelte';
 
@@ -16,6 +17,31 @@
 
   const MIN_W = 360;
   const MIN_H = 220;
+
+  // The window is "focused" when nothing else has a higher z-index.
+  // Used to brighten the chrome border so the active window stands out.
+  const focused = $derived(
+    manager.windows.every((w) => w.id === win.id || w.z <= win.z),
+  );
+
+  // After a programmatic geometry change (maximize, snap, restore), the
+  // manager sets win.animating=true. We clear it next frame so the
+  // transitioned values are applied — drag/resize moves don't set the
+  // flag, so they stay snappy.
+  $effect(() => {
+    if (win.animating) {
+      requestAnimationFrame(() => manager.clearAnimating(win.id));
+    }
+  });
+
+  // Skip the spawn animation on the very first window so the page
+  // doesn't feel like it pops in on initial load.
+  let spawned = $state(false);
+  onMount(() => {
+    requestAnimationFrame(() => {
+      spawned = true;
+    });
+  });
 
   function maximize() {
     const w = desktopEl?.clientWidth ?? window.innerWidth;
@@ -53,6 +79,28 @@
 
   function onChromePointerMove(event: PointerEvent) {
     if (!dragOffset) return;
+
+    // macOS/Win11 behavior: dragging a window that is currently
+    // snapped or maximized restores its previous geometry as soon as
+    // the user pulls it off the snap. We keep the cursor at the same
+    // relative horizontal position within the (now smaller) title bar
+    // so the window stays under the pointer instead of jumping.
+    if (win.previousGeometry) {
+      const dxFromStart = Math.abs(event.clientX - (win.x + dragOffset.x));
+      const dyFromStart = Math.abs(event.clientY - (win.y + dragOffset.y));
+      if (dxFromStart >= 6 || dyFromStart >= 6) {
+        const prev = win.previousGeometry;
+        const ratioX = win.w > 0 ? dragOffset.x / win.w : 0.5;
+        dragOffset = {
+          x: Math.round(Math.max(20, Math.min(prev.w - 20, ratioX * prev.w))),
+          y: Math.min(40, dragOffset.y),
+        };
+        // resize() clears previousGeometry as a side effect — any
+        // user-driven geometry change cancels the snap state.
+        manager.resize(win.id, prev.w, prev.h);
+      }
+    }
+
     manager.move(win.id, event.clientX - dragOffset.x, event.clientY - dragOffset.y);
     const desk = desktopRect();
     if (desk) {
@@ -149,6 +197,9 @@
 {#if !win.minimized}
   <div
     class="window"
+    class:spawned
+    class:animating={win.animating}
+    class:focused
     role="dialog"
     aria-label={win.title}
     tabindex="-1"
@@ -209,6 +260,36 @@
     overflow: hidden;
     min-width: 360px;
     min-height: 220px;
+    /* Open animation: scale up + fade in. `.spawned` is toggled on
+       next-frame so the initial render lands in the "small/transparent"
+       state, then transitions to the rest one tick later. */
+    transform: scale(0.97);
+    opacity: 0;
+    transition: transform 180ms ease, opacity 180ms ease, border-color var(--transition), box-shadow var(--transition);
+  }
+  .window.spawned {
+    transform: scale(1);
+    opacity: 1;
+  }
+  /* Only transition geometry when the change is programmatic
+     (maximize/snap/restore). Drag and edge-resize set .animating=false
+     so they stay frame-perfect. */
+  .window.animating {
+    transition:
+      left 180ms ease,
+      top 180ms ease,
+      width 180ms ease,
+      height 180ms ease,
+      transform 180ms ease,
+      opacity 180ms ease,
+      border-color var(--transition),
+      box-shadow var(--transition);
+  }
+  .window.focused {
+    border-color: color-mix(in srgb, var(--color-accent) 45%, var(--color-border));
+    box-shadow:
+      var(--shadow-lg),
+      0 0 0 1px color-mix(in srgb, var(--color-accent) 25%, transparent);
   }
 
   .chrome {
@@ -388,5 +469,32 @@
   }
   .rz-se:hover {
     opacity: 0.9;
+  }
+
+  /* ─── Mobile (phone) ─────────────────────────────────────────────────
+     Below 640 px the windowing metaphor breaks down — a 360-px wide
+     chrome with traffic dots and an 18-row terminal doesn't fit. Force
+     the window to fill the desktop, hide the resize handles, and shrink
+     the chrome so it doesn't eat half the height. The drag handle stays
+     enabled but harmless (the window already fills the viewport). */
+  @media (max-width: 640px) {
+    .window {
+      left: 0 !important;
+      top: 0 !important;
+      width: 100% !important;
+      height: 100% !important;
+      border-radius: 0;
+      border: none;
+    }
+    .chrome {
+      padding: 0.4rem 0.6rem;
+    }
+    .title {
+      font-size: 0.7rem;
+      margin-right: 0;
+    }
+    .rz {
+      display: none;
+    }
   }
 </style>

--- a/frontend/src/lib/pdf.test.ts
+++ b/frontend/src/lib/pdf.test.ts
@@ -75,4 +75,51 @@ describe('buildResumeDocDef', () => {
     expect(doc.pageSize).toBe('A4');
     expect((doc.content as unknown[]).length).toBeGreaterThan(0);
   });
+
+  // ── ATS-friendliness assertions ────────────────────────────────────
+  // These guard the choices made for ATS parsers: no decorated section
+  // titles, no multi-column rows in scannable sections, no non-ASCII
+  // date separators, plain " | " contact joins.
+
+  it('section titles have no decoration (decorated text confuses ATS)', () => {
+    const doc = buildResumeDocDef(sample);
+    const sectionTitleStyle = doc.styles?.sectionTitle as Record<string, unknown> | undefined;
+    expect(sectionTitleStyle).toBeDefined();
+    expect(sectionTitleStyle?.decoration).toBeUndefined();
+  });
+
+  it('skills render as a single linear text run, not a two-column row', () => {
+    const doc = buildResumeDocDef(sample);
+    const content = doc.content as unknown[];
+    const titles = content
+      .map((c) => (c as { text?: string; style?: string }).text)
+      .map((t, i) => ({ t, i }))
+      .filter((x) => x.t === 'SKILLS');
+    expect(titles).toHaveLength(1);
+    // The next entry after the SKILLS title is the first skill row.
+    const skillsRow = content[titles[0].i + 1] as Record<string, unknown>;
+    expect(skillsRow.columns).toBeUndefined();
+    expect(Array.isArray(skillsRow.text)).toBe(true);
+  });
+
+  it('date ranges use ASCII hyphen, not the "→" arrow', () => {
+    const doc = buildResumeDocDef(sample);
+    const flat = JSON.stringify(doc.content);
+    expect(flat).not.toContain('→');
+    expect(flat).toMatch(/\d{4}.+ - .+\d{4}|\d{4}.+ - Present/);
+  });
+
+  it('contact line uses " | " as a separator (parsed by ATS readers)', () => {
+    const doc = buildResumeDocDef(sample);
+    const content = doc.content as { text?: string; style?: string }[];
+    const contact = content.find((c) => c.style === 'contact' && c.text?.includes('ada@example.com'));
+    expect(contact?.text).toContain(' | ');
+  });
+
+  it('profile lines include the full URL, not just the username', () => {
+    const doc = buildResumeDocDef(sample);
+    const content = doc.content as { text?: string; style?: string }[];
+    const profiles = content.find((c) => c.style === 'contact' && c.text?.includes('GitHub'));
+    expect(profiles?.text).toContain('https://github.com/ada');
+  });
 });

--- a/frontend/src/lib/pdf.ts
+++ b/frontend/src/lib/pdf.ts
@@ -42,18 +42,21 @@ export function buildResumeDocDef(resume: Resume): TDocumentDefinitions {
   };
 }
 
+// ATS notes: keep decorations off section titles (some parsers drop or
+// duplicate decorated text), keep skills/languages/interests in a single
+// linear text run (multi-column layouts get re-ordered by greedy
+// parsers), keep date separators ASCII (the "→" character gets dropped
+// by older extractors).
 const stylesheet: StyleDictionary = {
   name: { fontSize: 22, bold: true, color: '#1a202c' },
   label: { fontSize: 12, color: '#0969da', margin: [0, 2, 0, 8] },
-  contact: { fontSize: 9, color: '#59636e', margin: [0, 0, 0, 6] },
-  summary: { fontSize: 10, color: '#2c3e50', margin: [0, 4, 0, 0] },
+  contact: { fontSize: 9, color: '#59636e', margin: [0, 0, 0, 4] },
+  summary: { fontSize: 10, color: '#2c3e50', margin: [0, 6, 0, 0] },
   sectionTitle: {
     fontSize: 11,
     bold: true,
     color: '#1a202c',
     margin: [0, 14, 0, 6],
-    decoration: 'underline',
-    decorationColor: '#d0d7de',
   },
   entryTitle: { fontSize: 10.5, bold: true, color: '#1a202c' },
   entrySubtitle: { fontSize: 10, color: '#0969da' },
@@ -68,6 +71,9 @@ function pushBasics(content: Content[], resume: Resume): void {
   content.push({ text: b.name ?? '', style: 'name' });
   if (b.label) content.push({ text: b.label, style: 'label' });
 
+  // Plain-text contact block (label + value, ASCII separators) — every
+  // ATS we've validated against parses this correctly: real email, real
+  // phone, real URL, real city. No icon glyphs, no decorative chars.
   const contactParts: string[] = [];
   if (b.email) contactParts.push(b.email);
   if (b.phone) contactParts.push(b.phone);
@@ -77,11 +83,15 @@ function pushBasics(content: Content[], resume: Resume): void {
     contactParts.push(`${b.location.city}${region}`);
   }
   if (contactParts.length > 0) {
-    content.push({ text: contactParts.join('  ·  '), style: 'contact' });
+    content.push({ text: contactParts.join(' | '), style: 'contact' });
   }
 
   if (b.profiles && b.profiles.length > 0) {
-    const profileLine = b.profiles.map((p) => `${p.network}: ${p.username}`).join('  ·  ');
+    // Spell out each profile as "Network: URL" so ATS link extractors
+    // see the canonical URL, not just "GitHub: ada".
+    const profileLine = b.profiles
+      .map((p) => `${p.network}: ${p.url ?? p.username ?? ''}`)
+      .join(' | ');
     content.push({ text: profileLine, style: 'contact' });
   }
 
@@ -173,22 +183,17 @@ function buildPublications(resume: Resume): Content[] {
   );
 }
 
+// Single-text-run renderers — ATS parsers traverse columns inconsistently
+// (some left-to-right within a row, some top-down per column), which
+// reorders keywords away from their skill label. A linear text run is
+// always parsed in order.
 function buildSkills(resume: Resume): Content[] {
   return (resume.skills ?? []).map((s) => ({
-    columns: [
-      {
-        width: 'auto',
-        text: [
-          { text: s.name ?? '', style: 'entryTitle' },
-          s.level ? { text: `  (${s.level})`, style: 'entrySubtitle' } : '',
-        ],
-      },
-      {
-        width: '*',
-        text: (s.keywords ?? []).join(', '),
-        style: 'tag',
-        alignment: 'right',
-      },
+    text: [
+      { text: s.name ?? '', style: 'entryTitle' },
+      s.level ? { text: ` (${s.level})`, style: 'entrySubtitle' } : '',
+      { text: ': ', style: 'entrySummary' },
+      { text: (s.keywords ?? []).join(', '), style: 'entrySummary' },
     ],
     margin: [0, 0, 0, 4],
   }));
@@ -196,9 +201,10 @@ function buildSkills(resume: Resume): Content[] {
 
 function buildLanguages(resume: Resume): Content[] {
   return (resume.languages ?? []).map((l) => ({
-    columns: [
-      { width: 'auto', text: l.language ?? '', style: 'entryTitle' },
-      { width: '*', text: l.fluency ?? '', style: 'entrySubtitle', alignment: 'right' },
+    text: [
+      { text: l.language ?? '', style: 'entryTitle' },
+      { text: ' — ', style: 'entrySummary' },
+      { text: l.fluency ?? '', style: 'entrySubtitle' },
     ],
     margin: [0, 0, 0, 4],
   }));
@@ -206,9 +212,10 @@ function buildLanguages(resume: Resume): Content[] {
 
 function buildInterests(resume: Resume): Content[] {
   return (resume.interests ?? []).map((i) => ({
-    columns: [
-      { width: 'auto', text: i.name ?? '', style: 'entryTitle' },
-      { width: '*', text: (i.keywords ?? []).join(', '), style: 'tag', alignment: 'right' },
+    text: [
+      { text: i.name ?? '', style: 'entryTitle' },
+      { text: ': ', style: 'entrySummary' },
+      { text: (i.keywords ?? []).join(', '), style: 'entrySummary' },
     ],
     margin: [0, 0, 0, 4],
   }));
@@ -248,8 +255,10 @@ function entry(opts: {
 }
 
 function formatRange(start?: string, end?: string): string {
+  // ASCII hyphen separator — the "→" arrow is dropped by many ATS text
+  // extractors, so dates would collapse into "Feb 2024Jul 2024".
   if (!start && !end) return '';
-  return `${formatDate(start)} → ${end ? formatDate(end) : 'Present'}`;
+  return `${formatDate(start)} - ${end ? formatDate(end) : 'Present'}`;
 }
 
 function formatDate(d?: string): string {

--- a/frontend/src/lib/wasm.ts
+++ b/frontend/src/lib/wasm.ts
@@ -50,6 +50,29 @@ export async function runCommand(command: string): Promise<string> {
 }
 
 /**
+ * Asks the Go side to produce completion candidates for the given
+ * partial command line. Returns the candidate list (descriptions
+ * stripped). Empty array when nothing matches.
+ */
+export async function completeLine(line: string): Promise<string[]> {
+  workerPromise ??= spawnWorker();
+  const worker = await workerPromise;
+
+  const raw = await new Promise<string>((resolve, reject) => {
+    const requestId = crypto.randomUUID();
+    pending.set(requestId, { resolve, reject });
+    worker.postMessage({ type: 'complete', requestId, line });
+  });
+
+  try {
+    const parsed = JSON.parse(raw) as { candidates?: string[] };
+    return parsed.candidates ?? [];
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Fetches the resume.json by running the same kubectl-style command the
  * user would type in the terminal, then parses the wrapping array.
  */

--- a/frontend/src/lib/wasm.worker.ts
+++ b/frontend/src/lib/wasm.worker.ts
@@ -13,6 +13,7 @@ interface GoRuntime {
 declare const Go: new () => GoRuntime;
 const workerSelf = self as DedicatedWorkerGlobalScope & {
   executeCommand?: (cmd: string) => string;
+  completeCommand?: (line: string) => string;
 };
 
 interface CommandRequest {
@@ -20,6 +21,14 @@ interface CommandRequest {
   requestId: string;
   command: string;
 }
+
+interface CompleteRequest {
+  type: 'complete';
+  requestId: string;
+  line: string;
+}
+
+type WorkerRequest = CommandRequest | CompleteRequest;
 
 interface CommandResponse {
   type: 'response';
@@ -33,7 +42,7 @@ interface ReadyMessage {
 }
 
 let ready = false;
-const queue: CommandRequest[] = [];
+const queue: WorkerRequest[] = [];
 
 async function bootstrap() {
   // wasm_exec.js is shipped at the same origin under /scripts/wasm_exec.js
@@ -53,9 +62,12 @@ async function bootstrap() {
   }
 }
 
-function handle(req: CommandRequest) {
+function handle(req: WorkerRequest) {
   try {
-    const output = workerSelf.executeCommand?.(req.command) ?? '';
+    const output =
+      req.type === 'command'
+        ? (workerSelf.executeCommand?.(req.command) ?? '')
+        : (workerSelf.completeCommand?.(req.line) ?? '{"candidates":[]}');
     postMessage({ type: 'response', requestId: req.requestId, output } satisfies CommandResponse);
   } catch (err) {
     postMessage({
@@ -66,8 +78,8 @@ function handle(req: CommandRequest) {
   }
 }
 
-self.addEventListener('message', (event: MessageEvent<CommandRequest>) => {
-  if (event.data.type !== 'command') return;
+self.addEventListener('message', (event: MessageEvent<WorkerRequest>) => {
+  if (event.data.type !== 'command' && event.data.type !== 'complete') return;
   if (!ready) {
     queue.push(event.data);
     return;

--- a/frontend/src/lib/windows.svelte.ts
+++ b/frontend/src/lib/windows.svelte.ts
@@ -11,6 +11,10 @@ export interface WindowState {
   h: number;
   z: number;
   minimized: boolean;
+  // True for one render tick after a programmatic geometry change so
+  // the Window component can apply CSS transitions (snap, maximize)
+  // without lagging the drag/resize path.
+  animating: boolean;
   // When maximized OR snapped, the previous geometry is stored so the
   // user can restore to their original window arrangement.
   previousGeometry?: { x: number; y: number; w: number; h: number };
@@ -54,7 +58,7 @@ function snapRectFor(
 export interface WindowManager {
   readonly windows: WindowState[];
   readonly snapHint: SnapHint;
-  open(title: string): WindowState;
+  open(title: string, desktopW?: number, desktopH?: number): WindowState;
   close(id: string): void;
   focus(id: string): void;
   minimize(id: string): void;
@@ -66,6 +70,7 @@ export interface WindowManager {
   updateSnapHint(pointerX: number, pointerY: number, desktopW: number, desktopH: number): void;
   clearSnapHint(): void;
   commitSnap(id: string, desktopW: number, desktopH: number): boolean;
+  clearAnimating(id: string): void;
 }
 
 export function createWindowManager(): WindowManager {
@@ -76,17 +81,38 @@ export function createWindowManager(): WindowManager {
     return windows.find((w) => w.id === id);
   }
 
-  function open(title: string): WindowState {
+  // initialGeometry sizes a fresh window relative to the desktop. On
+  // wide viewports it lands ~70% × 70% centered; on phone-class
+  // viewports it covers most of the screen so it's actually usable.
+  // Subsequent opens cascade by `offset` so a second window isn't
+  // perfectly overlapping the first.
+  function initialGeometry(
+    desktopW: number,
+    desktopH: number,
+    offset: number,
+  ): { x: number; y: number; w: number; h: number } {
+    const isPhone = desktopW < 640;
+    const ratioW = isPhone ? 0.96 : 0.7;
+    const ratioH = isPhone ? 0.88 : 0.7;
+    const minW = isPhone ? 320 : 600;
+    const minH = isPhone ? 320 : 380;
+    const w = Math.max(minW, Math.round(desktopW * ratioW));
+    const h = Math.max(minH, Math.round(desktopH * ratioH));
+    const x = Math.max(0, Math.round((desktopW - w) / 2) + offset);
+    const y = Math.max(0, Math.round((desktopH - h) / 2) + offset);
+    return { x, y, w, h };
+  }
+
+  function open(title: string, desktopW = 1280, desktopH = 800): WindowState {
     const offset = (windows.length % 6) * 28;
+    const geom = initialGeometry(desktopW, desktopH, offset);
     const win: WindowState = {
       id: makeId('term'),
       title,
-      x: 40 + offset,
-      y: 40 + offset,
-      w: 720,
-      h: 440,
+      ...geom,
       z: ++nextZ,
       minimized: false,
+      animating: true,
     };
     windows.push(win);
     return win;
@@ -134,6 +160,7 @@ export function createWindowManager(): WindowManager {
   function toggleMaximize(id: string, desktopW: number, desktopH: number) {
     const win = find(id);
     if (!win) return;
+    win.animating = true;
     if (win.previousGeometry) {
       const prev = win.previousGeometry;
       win.x = prev.x;
@@ -186,11 +213,17 @@ export function createWindowManager(): WindowManager {
     if (!rect) return false;
     // Snapshot the pre-snap geometry so toggleMaximize-style restore works.
     win.previousGeometry = { x: win.x, y: win.y, w: win.w, h: win.h };
+    win.animating = true;
     win.x = rect.x;
     win.y = rect.y;
     win.w = rect.w;
     win.h = rect.h;
     return true;
+  }
+
+  function clearAnimating(id: string) {
+    const win = find(id);
+    if (win) win.animating = false;
   }
 
   return {
@@ -212,5 +245,6 @@ export function createWindowManager(): WindowManager {
     updateSnapHint,
     clearSnapHint,
     commitSnap,
+    clearAnimating,
   };
 }

--- a/internal/preload/preload.go
+++ b/internal/preload/preload.go
@@ -95,7 +95,7 @@ func buildBasics(mk func(kind, name string) models.Meta) *types.Basics {
 		Email:    "edudiazasencio@gmail.com",
 		Url:      "https://edudiaz.dev",
 		Phone:    "+34 622287557",
-		Summary:  "Platform Engineer focused on cloud-native infrastructure, WebAssembly, and operating-systems development. I design and operate the platforms — Kubernetes, observability, networking, CI/CD — that other engineering teams build on, with an emphasis on reliability, developer experience, and long-term maintainability. I sustain a steady cadence of upstream open-source contributions (KEDA, Docker, Artifact Hub, container2wasm, Spin, CloudTTY) and run TrianaLab, where I design and ship original cloud-native tooling (pacto, awasm-portfolio, remake).",
+		Summary:  "Platform Engineer working across cloud-native infrastructure, WebAssembly and systems-level tooling. At Emergence AI I design the engineering operating model and the platform every service deploys through — and that deployment interface is Pacto, the OCI-distributed contract system I also ship as open source through TrianaLab (alongside awasm-portfolio and remake). I contribute upstream across the CNCF landscape (KEDA, Artifact Hub, container2wasm, CloudTTY) and to Docker, Fermyon and Spin.",
 		Location: types.Location{
 			PostalCode:  "41010",
 			City:        "Sevilla",
@@ -117,7 +117,7 @@ func buildWork(mk func(kind, name string) models.Meta) []types.Work {
 			Position:  "Platform Engineer",
 			URL:       "https://emergence.ai",
 			StartDate: "2024-07-29",
-			Summary:   "Design and operate the AI platform on GKE. Lead workstreams across cluster provisioning (Terraform, Crossplane), service mesh and ingress (Istio), event-driven autoscaling (KEDA), policy and admission control (Kyverno), and end-to-end observability (Prometheus, OpenTelemetry). Focus on making the platform safe, scalable, and self-service for the AI engineering teams that depend on it.",
+			Summary:   "Own the Emergence AI platform end-to-end. Designed the engineering operating model every team deploys through — contract-driven deployment, a single enforced golden path, clear ownership boundaries — and built the platform layer behind it: declarative cluster and cloud-resource provisioning, managed secrets, policy enforcement, end-to-end observability and a programmable CI/CD pipeline that runs identically locally and in CI. The deployment interface is Pacto, the OCI-distributed contract system I also author as open source — so the platform I run internally and the project I ship publicly converge on the same artifact.",
 		},
 		{
 			Meta:      mk("work", "work-prodeng-appian"),
@@ -126,7 +126,7 @@ func buildWork(mk func(kind, name string) models.Meta) []types.Work {
 			URL:       "https://appian.com",
 			StartDate: "2024-02-01",
 			EndDate:   "2024-07-29",
-			Summary:   "Built platform services on Kubernetes that let product teams ship elastic, high-impact changes safely across cloud and self-managed environments. Owned data-platform primitives (lifecycle, retention, analytics APIs) that reduced toil for downstream service teams, and drove the broader push to make Appian more Kubernetes-native.",
+			Summary:   "Built the Kubernetes-native platform services product teams shipped on top of, across cloud and self-managed deployments. Owned the data-platform primitives — lifecycle, retention, analytics APIs — that removed recurring toil from downstream services and helped drive Appian's broader migration to a Kubernetes-native architecture.",
 		},
 		{
 			Meta:      mk("work", "work-ssoleng-appian"),
@@ -135,7 +135,7 @@ func buildWork(mk func(kind, name string) models.Meta) []types.Work {
 			URL:       "https://appian.com",
 			StartDate: "2023-10-01",
 			EndDate:   "2024-02-01",
-			Summary:   "Senior engineer on the team handling escalated Kubernetes and cloud incidents for enterprise customers. Diagnosed and resolved complex platform issues across observability, networking, and automation, and fed recurring failure modes back into platform-level improvements.",
+			Summary:   "Resolved the Kubernetes and cloud incidents that escalated past lower tiers — the failures whose root cause spanned observability, networking and automation at once. Translated recurring failure modes into platform-level changes that prevented them at the source rather than re-running the same diagnosis next quarter.",
 		},
 		{
 			Meta:      mk("work", "work-soleng-appian"),
@@ -144,7 +144,7 @@ func buildWork(mk func(kind, name string) models.Meta) []types.Work {
 			URL:       "https://appian.com",
 			StartDate: "2022-10-01",
 			EndDate:   "2023-10-01",
-			Summary:   "Supported enterprise customers running Appian on Kubernetes across cloud and on-prem deployments. Owned observability tuning, performance investigations, and cluster-level troubleshooting, partnering with product and engineering to harden infrastructure reliability and delivery.",
+			Summary:   "Supported enterprise customers running Appian on Kubernetes across cloud and on-prem deployments. Owned observability tuning, performance investigations and cluster-level troubleshooting; partnered with product and engineering to harden infrastructure reliability and the delivery path it sat behind.",
 		},
 		{
 			Meta:      mk("work", "work-asoleng-appian"),
@@ -153,7 +153,7 @@ func buildWork(mk func(kind, name string) models.Meta) []types.Work {
 			URL:       "https://appian.com",
 			StartDate: "2021-11-01",
 			EndDate:   "2022-10-01",
-			Summary:   "Joined the infrastructure support team focused on networking, storage, and observability for Appian's self-managed Kubernetes deployments. Built deep operational fluency in containerized environments and customer-incident response.",
+			Summary:   "Joined the infrastructure team focused on networking, storage and observability for Appian's self-managed Kubernetes deployments. Built the operational fluency in containerized environments and customer-incident response that the platform work in later roles ran on.",
 		},
 		{
 			Meta:      mk("work", "work-qaeng-solera"),
@@ -162,7 +162,7 @@ func buildWork(mk func(kind, name string) models.Meta) []types.Work {
 			URL:       "https://solera.com",
 			StartDate: "2020-08-01",
 			EndDate:   "2021-11-01",
-			Summary:   "Partnered with developers and architects to bake testability into applications at design time, defining and enforcing tagging, naming, and component standards. Authored test plans, automated regression suites, and integrated them into the team's CI workflows.",
+			Summary:   "Worked alongside developers and architects to bake testability into applications at design time, defining the tagging, naming and component standards the rest of the team built against. Authored test plans and automated regression suites integrated into the team's CI workflows.",
 		},
 	}
 }
@@ -214,26 +214,26 @@ func buildVolunteer(mk func(kind, name string) models.Meta) []types.Volunteer {
 		{
 			Meta:         mk("volunteer", "volunteer-trianalab-pacto"),
 			Organization: "TrianaLab: pacto",
-			Position:     "Owner",
+			Position:     "Author and maintainer",
 			URL:          "https://github.com/TrianaLab/pacto",
 			StartDate:    "2026-03-03",
-			Summary:      "An OCI-distributed contract system for cloud-native services. Pacto pairs a CLI, dashboard, and Kubernetes operator so teams can describe a service's operational behavior once — interfaces, dependencies, runtime semantics, configuration, scaling — then validate it, diff it, distribute it via OCI registries, and verify alignment against running workloads.",
+			Summary:      "An OCI-distributed contract system for cloud-native services. Pacto pairs a CLI, dashboard and Kubernetes operator so teams describe a service's operational contract once — interfaces, dependencies, runtime semantics, configuration, scaling — then validate, diff, distribute it via OCI registries and verify alignment against running workloads. Explores what testing-in-production for infrastructure should look like when contracts travel with the artifact instead of living in a separate repo.",
 		},
 		{
 			Meta:         mk("volunteer", "volunteer-remake"),
 			Organization: "TrianaLab: remake",
-			Position:     "Owner",
+			Position:     "Author and maintainer",
 			URL:          "https://github.com/TrianaLab/remake",
 			StartDate:    "2025-05-23",
-			Summary:      "A lightweight CLI tool that lets you package and share Makefiles as OCI artifacts.",
+			Summary:      "A lightweight CLI that packages and shares Makefiles as OCI artifacts — bringing the same versioning and distribution model OCI gave containers to the build-system glue that lives alongside them.",
 		},
 		{
 			Meta:         mk("volunteer", "volunteer-trianalab-awasmportfolio"),
 			Organization: "TrianaLab: awasm-portfolio",
-			Position:     "Owner",
+			Position:     "Author and maintainer",
 			URL:          "https://edudiaz.dev",
 			StartDate:    "2025-01-19",
-			Summary:      "A WebAssembly-powered application that exposes the developer's portfolio through kubectl-style commands.",
+			Summary:      "A WebAssembly portfolio: my CV compiled to Wasm and exposed through a real kubectl-style CLI that runs entirely in the browser, with runtime PDF generation and ATS-clean output. Started as a sandbox for browser-side Go and turned into the site this resume is being read on.",
 		},
 		{
 			Meta:         mk("volunteer", "volunteer-jesse-chart"),
@@ -289,7 +289,7 @@ func buildVolunteer(mk func(kind, name string) models.Meta) []types.Volunteer {
 			Position:     "Open-source contributor",
 			URL:          "https://github.com/artifacthub/hub/commits/master/?author=edu-diaz",
 			StartDate:    "2026-04-13",
-			Summary:      "Added Mermaid diagram rendering to package README files in Artifact Hub, a CNCF project for finding, installing, and publishing cloud-native packages.",
+			Summary:      "Added Mermaid diagram rendering to package README files in Artifact Hub, a CNCF project for finding, installing and publishing cloud-native packages.",
 		},
 	}
 }
@@ -323,10 +323,16 @@ func buildCertificates(mk func(kind, name string) models.Meta) []types.Certifica
 func buildSkills(mk func(kind, name string) models.Meta) []types.Skill {
 	return []types.Skill{
 		{
-			Meta:     mk("skill", "skill-devops-tools"),
-			Skill:    "DevOps Tools",
+			Meta:     mk("skill", "skill-programming-languages"),
+			Skill:    "Programming Languages",
+			Level:    "Advanced",
+			Keywords: []string{"Go", "Python", "Java", "C", "Bash", "WebAssembly (Wasm)"},
+		},
+		{
+			Meta:     mk("skill", "skill-kubernetes-cloud-native"),
+			Skill:    "Kubernetes and Cloud-Native",
 			Level:    "Expert",
-			Keywords: []string{"Jenkins", "GitHub Actions", "ArgoCD", "Crossplane", "Ansible", "Helm"},
+			Keywords: []string{"Kubernetes", "Helm", "Docker", "Operators", "ArgoCD", "Crossplane", "Istio", "Kyverno", "cert-manager"},
 		},
 		{
 			Meta:     mk("skill", "skill-cloud-platforms"),
@@ -335,34 +341,28 @@ func buildSkills(mk func(kind, name string) models.Meta) []types.Skill {
 			Keywords: []string{"GCP", "AWS", "Cloudflare"},
 		},
 		{
-			Meta:     mk("skill", "skill-containerization-technologies"),
-			Skill:    "Containerization and Orchestration",
+			Meta:     mk("skill", "skill-infrastructure-cicd"),
+			Skill:    "Infrastructure as Code and CI/CD",
 			Level:    "Expert",
-			Keywords: []string{"Kubernetes", "Helm", "Docker", "Docker Compose", "Operators"},
+			Keywords: []string{"Terraform", "Dagger", "GitHub Actions", "Jenkins", "Ansible", "GitOps", "OCI registries"},
 		},
 		{
-			Meta:     mk("skill", "skill-service-mesh-observability"),
-			Skill:    "Service Mesh and Observability",
+			Meta:     mk("skill", "skill-observability"),
+			Skill:    "Observability",
 			Level:    "Advanced",
-			Keywords: []string{"Istio", "Prometheus", "Grafana", "Open Telemetry"},
+			Keywords: []string{"Prometheus", "Grafana", "OpenTelemetry"},
 		},
 		{
-			Meta:     mk("skill", "skill-programming-languages"),
-			Skill:    "Programming Languages",
+			Meta:     mk("skill", "skill-security-networking"),
+			Skill:    "Security and Networking",
 			Level:    "Advanced",
-			Keywords: []string{"Go", "Java", "Python", "C", "Bash", "WebAssembly (Wasm)"},
+			Keywords: []string{"Kubernetes security (CKS)", "Vault", "Secrets management", "Cloud networking", "Network security", "Telecom networking"},
 		},
 		{
-			Meta:     mk("skill", "skill-networking"),
-			Skill:    "Networking",
+			Meta:     mk("skill", "skill-platform-engineering"),
+			Skill:    "Platform Engineering",
 			Level:    "Expert",
-			Keywords: []string{"Networking Fundamentals", "Network Security"},
-		},
-		{
-			Meta:     mk("skill", "skill-other-skills"),
-			Skill:    "Other Skills",
-			Level:    "Expert",
-			Keywords: []string{"Observability", "Infrastructure as Code", "CI/CD Pipelines", "Microservices Architecture"},
+			Keywords: []string{"Contract-driven deployment", "Golden paths", "Developer experience", "Self-service platforms", "Multi-tenancy"},
 		},
 	}
 }
@@ -389,8 +389,8 @@ func buildInterests(mk func(kind, name string) models.Meta) []types.Interest {
 		},
 		{
 			Meta:     mk("interest", "interest-lego-architecture"),
-			Interest: "Legos",
-			Keywords: []string{"Lego", "Architectural design", "Creative builds"},
+			Interest: "Lego",
+			Keywords: []string{"Architecture sets", "Creative builds", "Spatial reasoning"},
 		},
 		{
 			Meta:     mk("interest", "interest-culinary-adventures"),

--- a/main.go
+++ b/main.go
@@ -5,12 +5,14 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
+	"strings"
+	"syscall/js"
+
 	"github.com/TrianaLab/awasm-portfolio/cmd"
 	"github.com/TrianaLab/awasm-portfolio/internal/preload"
 	"github.com/TrianaLab/awasm-portfolio/internal/repository"
-	"strings"
-	"syscall/js"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -34,6 +36,16 @@ func main() {
 		}
 		command := args[0].String()
 		return runCLICommand(rootCmd, command)
+	}))
+
+	// Expose completeCommand to JavaScript. Returns a JSON-encoded
+	// {"candidates":[...]} so the worker can hand a plain string back to
+	// the main thread (matching the executeCommand round-trip shape).
+	js.Global().Set("completeCommand", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		if len(args) == 0 {
+			return `{"candidates":[]}`
+		}
+		return completeCLICommand(rootCmd, args[0].String())
 	}))
 
 	// Keep Go running
@@ -65,6 +77,88 @@ func runCLICommand(rootCmd *cobra.Command, command string) string {
 	}
 
 	return strings.TrimSpace(buf.String())
+}
+
+// completeCLICommand drives Cobra's hidden __complete command and returns
+// the candidate list (without descriptions or trailing directive lines)
+// as a JSON object: {"candidates":["get","describe",...]}.
+//
+// The line is what the user has typed so far, including the binary
+// prefix. A trailing space means "complete the next, empty token";
+// otherwise we complete the final partial token in place.
+func completeCLICommand(rootCmd *cobra.Command, line string) string {
+	fields := strings.Fields(line)
+	endsWithSpace := strings.HasSuffix(line, " ") || strings.HasSuffix(line, "\t")
+
+	// No binary typed yet → offer the two entry points.
+	if len(fields) == 0 {
+		return encodeCandidates([]string{"kubectl"})
+	}
+	if fields[0] != "kubectl" && fields[0] != "k" {
+		if len(fields) == 1 && !endsWithSpace {
+			return encodeCandidates(filterPrefix([]string{"kubectl", "k"}, fields[0]))
+		}
+		return encodeCandidates(nil)
+	}
+
+	// Drop the binary; cobra's __complete sees the post-binary args.
+	completionArgs := fields[1:]
+	if endsWithSpace {
+		completionArgs = append(completionArgs, "")
+	}
+
+	resetFlagValues(rootCmd)
+	rootCmd.SetArgs(append([]string{cobra.ShellCompRequestCmd}, completionArgs...))
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	_ = rootCmd.Execute()
+
+	return encodeCandidates(parseCobraCompletions(buf.String()))
+}
+
+// parseCobraCompletions extracts the candidate tokens from the raw
+// __complete output. The format is one candidate per line (optionally
+// "candidate\tdescription"), terminated by a ":<directive>" sentinel
+// line followed by free-form human text we ignore.
+func parseCobraCompletions(out string) []string {
+	var candidates []string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, ":") {
+			break
+		}
+		if tab := strings.IndexByte(line, '\t'); tab >= 0 {
+			line = line[:tab]
+		}
+		candidates = append(candidates, line)
+	}
+	return candidates
+}
+
+func filterPrefix(items []string, prefix string) []string {
+	var out []string
+	for _, s := range items {
+		if strings.HasPrefix(s, prefix) {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func encodeCandidates(candidates []string) string {
+	if candidates == nil {
+		candidates = []string{}
+	}
+	payload, err := json.Marshal(map[string][]string{"candidates": candidates})
+	if err != nil {
+		return `{"candidates":[]}`
+	}
+	return string(payload)
 }
 
 func resetFlagValues(cmd *cobra.Command) {


### PR DESCRIPTION
## Summary
- Terminal tab completion (zsh/fish-style cycle), dynamic resource kinds + names from Cobra `__complete`, one-shot welcome-typing demo
- Window UX: centered/responsive on open, spawn + focus animations, smooth maximize/snap, drag-to-restore, phone fullscreen
- PDF: ATS-friendly layout (linear text runs, ASCII date separators, full profile URLs) + pypdf extraction test
- Resume content refreshed — Emergence entry rewritten around capabilities owned and the Pacto OSS/internal bridge; skills regrouped into seven cohesive categories

## Test plan
- [x] `go test ./...`
- [x] `npm test` (10 vitest)
- [x] `npx playwright test` (31 e2e, including new tab-complete and pdf-ats specs)