### PR TITLE
ci: make Codecov upload non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   frontend:
     runs-on: ubuntu-latest


### PR DESCRIPTION
the unit-test job goes red on the codecov upload step, not on the tests. codecov-action can't import codecov's gpg key in ci ("no valid OpenPGP data found" then "Can't check signature: No public key"), so its binary integrity check fails and `fail_ci_if_error: true` turns that into a failed job. the go tests themselves pass, and a re-run failed the same way, so it's persistent.

this makes the codecov upload non-blocking so codecov's own tooling breaking doesn't gate CI. coverage still uploads whenever it works.
