### PR TITLE
ci: drop failing type=gha build cache from deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -106,8 +106,6 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ghcr.io/${{ steps.repo.outputs.name }}:${{ needs.resolve.outputs.tag }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           build-args: |
             VERSION=${{ needs.resolve.outputs.tag }}
             GIT_COMMIT=${{ github.sha }}


### PR DESCRIPTION
the docker build in the deploy workflow fails every time on `error writing layer blob: failed to reserve cache`. it's the buildx `type=gha` cache not working with github's newer actions cache service, not a cache-full thing (the repo cache is ~100mb). the image itself builds fine, it only dies writing the build cache.

dropping `cache-from`/`cache-to: type=gha` so the deploy stops failing. builds are a touch slower without the layer cache but reliable.
